### PR TITLE
For Ubuntu 18.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+CXX=g++-8
+
 CXXFLAGS = -Wall -O2 -std=c++17
 
 LIBPATH = -L/opt/rocm/opencl/lib/x86_64 -L/opt/amdgpu-pro/lib/x86_64-linux-gnu -L/c/Windows/System32 -L.


### PR DESCRIPTION
stdc++fs is not available, switch to \<filesystem\>. G++-8 has become a requirement for Ubuntu 18.04.