### PR TITLE
Merged transpose and middleIn/Out

### DIFF
--- a/Args.cpp
+++ b/Args.cpp
@@ -57,6 +57,7 @@ Command line options:
 -B1                : P-1 B1 bound, default %u
 -B2                : P-1 B2 bound, default B1 * 30
 -rB2               : ratio of B2 to B1. Default %u, used only if B2 is not explicitly set
+-cleanup           : delete save files at end of run
 -prp <exponent>    : run a single PRP test and exit, ignoring worktodo.txt
 -pm1 <exponent>    : run a single P-1 test and exit, ignoring worktodo.txt
 -results <file>    : name of results file, default 'results.txt'
@@ -120,6 +121,7 @@ void Args::parse(string line) {
     else if (key == "-device" || key == "-d") { device = stoi(s); }
     else if (key == "-dir") { dir = s; }
     else if (key == "-yield") { cudaYield = true; }
+    else if (key == "-cleanup") { cleanup = true; }
     else if (key == "-carry") {
       if (s == "short" || s == "long") {
         carry = s == "short" ? CARRY_SHORT : CARRY_LONG;

--- a/Args.h
+++ b/Args.h
@@ -28,6 +28,7 @@ public:
   bool timeKernels = false;
   bool enableTF = false;
   bool cudaYield = false;
+  bool cleanup = false;
   u32 proofPow = 0;
   
   int carry = CARRY_AUTO;

--- a/Gpu.cpp
+++ b/Gpu.cpp
@@ -487,6 +487,7 @@ void Gpu::exponentiate(const Buffer<double>& base, u64 exp, Buffer<double>& tmp,
 
         // multiply from low
         multiply(out, base);
+	fftHout(out);
         topHalf(out, tmp);
       }
       if (p <= 0) { break; }
@@ -882,7 +883,7 @@ std::variant<string, vector<u32>> Gpu::factorPM1(u32 E, const Args& args, u32 B1
     bool doLog = (k + 1) % 10000 == 0; // || isAtEnd;
     bool doStop = signal.stopRequested();
     if (doStop) { log("Stopping, please wait..\n"); }
-    bool doSave = doStop || saveTimer.elapsed() > 300 || isAtEnd;
+    bool doSave = doStop || saveTimer.elapsedSecs() > 300 || isAtEnd;
 
     bool leadOut = useLongCarry || doLog || doSave;
     coreStep(leadIn, leadOut, bits[k], bufAux, bufTmp, bufData);

--- a/Gpu.h
+++ b/Gpu.h
@@ -28,6 +28,7 @@ class Gpu {
   u32 hN, nW, nH, bufSize;
   bool useLongCarry;
   bool useMiddle;
+  bool useMergedMiddle;
   bool timeKernels;
 
   cl_device_id device;
@@ -118,7 +119,7 @@ class Gpu {
   void writeState(const vector<u32> &check, u32 blockSize, Buffer<double>&, Buffer<double>&, Buffer<double>&);
 
   Gpu(const Args& args, u32 E, u32 W, u32 BIG_H, u32 SMALL_H, u32 nW, u32 nH,
-      cl_device_id device, bool timeKernels, bool useLongCarry, struct Weights&& weights);
+      cl_device_id device, bool timeKernels, bool useLongCarry, bool useMergedMiddle, struct Weights&& weights);
 
   vector<u32> readAndCompress(ConstBuffer<int>& buf);
   
@@ -126,7 +127,7 @@ public:
   static unique_ptr<Gpu> make(u32 E, const Args &args);
   
   Gpu(const Args& args, u32 E, u32 W, u32 BIG_H, u32 SMALL_H, u32 nW, u32 nH,
-      cl_device_id device, bool timeKernels, bool useLongCarry);
+      cl_device_id device, bool timeKernels, bool useLongCarry, bool useMergedMiddle);
 
   vector<u32> roundtripData()  { return readData(); }
   vector<u32> roundtripCheck() { return readCheck(); }

--- a/Gpu.h
+++ b/Gpu.h
@@ -39,7 +39,8 @@ class Gpu {
   Kernel carryFusedMul;
   Kernel fftP;
   Kernel fftW;
-  Kernel fftH;
+  Kernel fftHin;
+  Kernel fftHout;
   Kernel fftMiddleIn;
   Kernel fftMiddleOut;
   

--- a/Task.cpp
+++ b/Task.cpp
@@ -7,6 +7,7 @@
 #include "File.h"
 #include "GmpUtil.h"
 #include "Background.h"
+#include "checkpoint.h"
 #include "version.h"
 
 #include <cstdio>
@@ -81,6 +82,7 @@ bool Task::execute(const Args& args, Background& background) {
     if (args.proofPow) {
       gpu->buildProof(exponent, args);
     }
+    if (args.cleanup && !isPrime) deleteSaveFiles(exponent);
     return true;
   } else if (kind == PM1) {
     auto result = gpu->factorPM1(exponent, args, B1, B2);

--- a/checkpoint.cpp
+++ b/checkpoint.cpp
@@ -9,6 +9,12 @@
 
 namespace fs = std::filesystem;
 
+void deleteSaveFiles(u32 E) {
+  string sE = to_string(E);
+  auto baseDir = fs::current_path() / sE;
+  fs::remove_all(baseDir);
+}
+
 static fs::path fileName(u32 E, u32 k, const string& suffix = "", const string& extension = "owl") {
   string sE = to_string(E);
   auto baseDir = fs::current_path() / sE;

--- a/checkpoint.h
+++ b/checkpoint.h
@@ -11,6 +11,8 @@
 
 u64 residue(const vector<u32> &words);
 
+void deleteSaveFiles(u32 E);
+
 class StateLoader {
 protected:
   virtual ~StateLoader() = default;


### PR DESCRIPTION
I've run out of optimizations to try.   I'm running this version in a production environments for 24 hours without issue.   Needs more QA with different FFT sizes, P-1, proofs, etc.

Also, if -use MERGED_MIDDLE is to become the default option, the code will need to be reworked somewhat.
