### PR TITLE
Added original middlemul1 implementation.  Added unroll_middlemul1 and 2.

### DIFF
--- a/gpuowl.cl
+++ b/gpuowl.cl
@@ -61,6 +61,79 @@ typedef ulong u64;
 #define G_W (WIDTH / NW)
 #define G_H (SMALL_HEIGHT / NH)
 
+// The ROCm optimizer does a very, very poor job of keeping register usage to a minimum.  Thus negatively impacts occupancy
+// which can make a big performance difference.  To counteract this, we can prevent some loops from being unrolled.
+// For AMD GPUs we default to unrolling fft_HEIGHT but not fft_WIDTH loops.  For nVidia GPUs, we unroll everything.
+
+#if !defined(UNROLL_ALL) && !defined(UNROLL_NONE) && !defined(UNROLL_WIDTH) && !defined(UNROLL_HEIGHT)
+#ifdef AMDGPU
+#define UNROLL_HEIGHT
+#else
+#define UNROLL_ALL
+#endif
+#endif
+
+#if defined(UNROLL_ALL) || defined(UNROLL_WIDTH)
+#define UNROLL_WIDTH_CONTROL
+#else
+#define UNROLL_WIDTH_CONTROL	  __attribute__((opencl_unroll_hint(1)))
+#endif
+
+#if defined(UNROLL_ALL) || defined(UNROLL_HEIGHT)
+#define UNROLL_HEIGHT_CONTROL
+#else
+#define UNROLL_HEIGHT_CONTROL	  __attribute__((opencl_unroll_hint(1)))
+#endif
+
+
+// A T2 shuffle requires twice as much local memory as a T shuffle.  This won't affect occupancy for MIDDLE shuffles
+// and small WIDTH and HEIGHT shuffles.  However, 4K and 2K widths and heights might be better off using less local memory.
+// Consequently, we have separate defines so we can selectively do T2 shuffling.  For now we assume the original code
+// that does 64x64 shuffles uses so much local memory that we'll not offer a T2 shuffle in there.
+//
+// For a 5M FFT on a Radeon VII, the best combination is T2_SHUFFLE_MIDDLE,T2_SHUFFLE_REVERSELINE, but
+// not T2_SHUFFLE_WIDTH,T2_SHUFFLE_HEIGHT.  This may indicate that any speed differences are due to vagaries of
+// the ROCm optimizer rather than an inherit benefit of T2 vs. T shuffles.  The AMD OpenCL optimization manual says
+// T shuffles should give the best performance.
+
+#if !defined(T2_SHUFFLE) && !defined(NO_T2_SHUFFLE) && !defined(T2_SHUFFLE_WIDTH) && !defined(T2_SHUFFLE_MIDDLE) && !defined(T2_SHUFFLE_HEIGHT) && !defined(T2_SHUFFLE_REVERSELINE)
+#ifdef AMDGPU
+#define T2_SHUFFLE_MIDDLE
+#define T2_SHUFFLE_REVERSELINE
+#endif
+#endif
+
+#if defined(T2_SHUFFLE) || defined(T2_SHUFFLE_WIDTH)
+#undef T2_SHUFFLE_WIDTH
+#define T2_SHUFFLE_WIDTH	1
+#else
+#define T2_SHUFFLE_WIDTH	2
+#endif
+#if defined(T2_SHUFFLE) || defined(T2_SHUFFLE_MIDDLE)
+#undef T2_SHUFFLE_MIDDLE
+#define T2_SHUFFLE_MIDDLE	1
+#else
+#define T2_SHUFFLE_MIDDLE	2
+#endif
+#if defined(T2_SHUFFLE) || defined(T2_SHUFFLE_HEIGHT)
+#undef T2_SHUFFLE_HEIGHT
+#define T2_SHUFFLE_HEIGHT	1
+#else
+#define T2_SHUFFLE_HEIGHT	2
+#endif
+#if defined(T2_SHUFFLE) || defined(T2_SHUFFLE_REVERSELINE)
+#undef T2_SHUFFLE_REVERSELINE
+#define T2_SHUFFLE_REVERSELINE	1
+#else
+#define T2_SHUFFLE_REVERSELINE	2
+#endif
+
+#if T2_SHUFFLE_HEIGHT == 1 || T2_SHUFFLE_REVERSELINE == 1
+#define T2_SHUFFLE_TAILFUSED	1
+#else
+#define T2_SHUFFLE_TAILFUSED	2
+#endif
+
 typedef double T;
 typedef double2 T2;
 typedef i32 Word;
@@ -877,16 +950,46 @@ void fft12(T2 *u) {
   u[7] = tmp68a - tmp68b;
 }
 
-void shufl(u32 WG, local T *lds, T2 *u, u32 n, u32 f) {
+
+// NOTE: I tried merging shuflw and shuflh by passing in the appropriate T2_SHUFFLE flag as an argument
+// but the rocm compiler was not up to generating the most efficient code.
+
+void shuflw(u32 WG, local T2 *lds, T2 *u, u32 n, u32 f) {
   u32 me = get_local_id(0);
   u32 m = me / f;
-  
+
+#if T2_SHUFFLE_WIDTH == 1
+  bar();
+  for (u32 i = 0; i < n; ++i) { lds[(m + i * WG / f) / n * f + m % n * WG + me % f] = u[i]; }
+  bar();
+  for (u32 i = 0; i < n; ++i) { u[i] = lds[i * WG + me]; }
+#else
   for (i32 b = 0; b < 2; ++b) {
     bar();
-    for (u32 i = 0; i < n; ++i) { lds[(m + i * WG / f) / n * f + m % n * WG + me % f] = ((T *) (u + i))[b]; }
+    for (u32 i = 0; i < n; ++i) { ((local T*)lds)[(m + i * WG / f) / n * f + m % n * WG + me % f] = ((T *) (u + i))[b]; }
     bar();
-    for (u32 i = 0; i < n; ++i) { ((T *) (u + i))[b] = lds[i * WG + me]; }
+    for (u32 i = 0; i < n; ++i) { ((T *) (u + i))[b] = ((local T*)lds)[i * WG + me]; }
   }
+#endif
+}
+
+void shuflh(u32 WG, local T2 *lds, T2 *u, u32 n, u32 f) {
+  u32 me = get_local_id(0);
+  u32 m = me / f;
+
+#if T2_SHUFFLE_HEIGHT == 1
+  bar();
+  for (u32 i = 0; i < n; ++i) { lds[(m + i * WG / f) / n * f + m % n * WG + me % f] = u[i]; }
+  bar();
+  for (u32 i = 0; i < n; ++i) { u[i] = lds[i * WG + me]; }
+#else
+  for (i32 b = 0; b < 2; ++b) {
+    bar();
+    for (u32 i = 0; i < n; ++i) { ((local T*)lds)[(m + i * WG / f) / n * f + m % n * WG + me % f] = ((T *) (u + i))[b]; }
+    bar();
+    for (u32 i = 0; i < n; ++i) { ((T *) (u + i))[b] = ((local T*)lds)[i * WG + me]; }
+  }
+#endif
 }
 
 void tabMul(u32 WG, const global T2 *trig, T2 *u, u32 n, u32 f) {
@@ -894,87 +997,129 @@ void tabMul(u32 WG, const global T2 *trig, T2 *u, u32 n, u32 f) {
   for (i32 i = 1; i < n; ++i) { u[i] = mul(u[i], trig[me / f + i * (WG / f)]); }
 }
 
-void shuflAndMul(u32 WG, local T *lds, const global T2 *trig, T2 *u, u32 n, u32 f) {
-#if 0
-  u32 me = get_local_id(0);
-  u32 m = me / f;
-  
-  for (i32 b = 0; b < 2; ++b) {
-    bar();
-    for (u32 i = 0; i < n; ++i) { lds[(m + i * WG / f) / n * f + m % n * WG + me % f] = ((T *) (u + i))[b]; }
-    bar();
-    for (u32 i = 0; i < n; ++i) { ((T *) (u + i))[b] = lds[i * WG + me]; }
-  }
-
-  for (i32 i = 1; i < n; ++i) { u[i] = mul(u[i], trig[me / f + i * (WG / f)]); }  
-#else
-  shufl(WG, lds, u, n, f);
+void shuflAndMulw(u32 WG, local T2 *lds, const global T2 *trig, T2 *u, u32 n, u32 f) {
+  shuflw(WG, lds, u, n, f);
   tabMul(WG, trig, u, n, f);
-#endif
+}
+
+void shuflAndMulh(u32 WG, local T2 *lds, const global T2 *trig, T2 *u, u32 n, u32 f) {
+  shuflh(WG, lds, u, n, f);
+  tabMul(WG, trig, u, n, f);
 }
 
 // 8x8
-void fft64(local T *lds, T2 *u, const global T2 *trig) {
+void fft64w(local T2 *lds, T2 *u, const global T2 *trig) {
   fft8(u);
-  shuflAndMul(8, lds, trig, u, 8, 1);
+  shuflAndMulw(8, lds, trig, u, 8, 1);
+  fft8(u);
+}
+void fft64h(local T2 *lds, T2 *u, const global T2 *trig) {
+  fft8(u);
+  shuflAndMulh(8, lds, trig, u, 8, 1);
   fft8(u);
 }
 
 // 64x4
-void fft256(local T *lds, T2 *u, const global T2 *trig) {
+void fft256w(local T2 *lds, T2 *u, const global T2 *trig) {
+  UNROLL_WIDTH_CONTROL
   for (i32 s = 4; s >= 0; s -= 2) {
     fft4(u);
-    shuflAndMul(64, lds, trig, u, 4, 1 << s);
+    shuflAndMulw(64, lds, trig, u, 4, 1 << s);
+  }
+  fft4(u);
+}
+void fft256h(local T2 *lds, T2 *u, const global T2 *trig) {
+  UNROLL_HEIGHT_CONTROL
+  for (i32 s = 4; s >= 0; s -= 2) {
+    fft4(u);
+    shuflAndMulh(64, lds, trig, u, 4, 1 << s);
   }
   fft4(u);
 }
 
 // 64x8
-void fft512(local T *lds, T2 *u, const global T2 *trig) {
+void fft512w(local T2 *lds, T2 *u, const global T2 *trig) {
+  UNROLL_WIDTH_CONTROL
   for (i32 s = 3; s >= 0; s -= 3) {
     fft8(u);
-    shuflAndMul(64, lds, trig, u, 8, 1 << s);
+    shuflAndMulw(64, lds, trig, u, 8, 1 << s);
+  }
+  fft8(u);
+}
+void fft512h(local T2 *lds, T2 *u, const global T2 *trig) {
+  UNROLL_HEIGHT_CONTROL
+  for (i32 s = 3; s >= 0; s -= 3) {
+    fft8(u);
+    shuflAndMulh(64, lds, trig, u, 8, 1 << s);
   }
   fft8(u);
 }
 
 // 256x4
-void fft1K(local T *lds, T2 *u, const global T2 *trig) {
+void fft1Kw(local T2 *lds, T2 *u, const global T2 *trig) {
+  UNROLL_WIDTH_CONTROL
   for (i32 s = 6; s >= 0; s -= 2) {
     fft4(u);
-    shuflAndMul(256, lds, trig, u, 4, 1 << s);
+    shuflAndMulw(256, lds, trig, u, 4, 1 << s);
+  }
+  fft4(u);
+}
+void fft1Kh(local T2 *lds, T2 *u, const global T2 *trig) {
+  UNROLL_HEIGHT_CONTROL
+  for (i32 s = 6; s >= 0; s -= 2) {
+    fft4(u);
+    shuflAndMulh(256, lds, trig, u, 4, 1 << s);
   }
   fft4(u);
 }
 
 // 512x8
-void fft4K(local T *lds, T2 *u, const global T2 *trig) {
+void fft4Kw(local T2 *lds, T2 *u, const global T2 *trig) {
+  UNROLL_WIDTH_CONTROL
   for (i32 s = 6; s >= 0; s -= 3) {
     fft8(u);
-    shuflAndMul(512, lds, trig, u, 8, 1 << s);
+    shuflAndMulw(512, lds, trig, u, 8, 1 << s);
+  }
+  fft8(u);
+}
+void fft4Kh(local T2 *lds, T2 *u, const global T2 *trig) {
+  UNROLL_HEIGHT_CONTROL
+  for (i32 s = 6; s >= 0; s -= 3) {
+    fft8(u);
+    shuflAndMulh(512, lds, trig, u, 8, 1 << s);
   }
   fft8(u);
 }
 
 // 256x8
-void fft2K(local T *lds, T2 *u, const global T2 *trig) {
+void fft2Kw(local T2 *lds, T2 *u, const global T2 *trig) {
+  UNROLL_WIDTH_CONTROL
   for (i32 s = 5; s >= 2; s -= 3) {
     fft8(u);
-    shuflAndMul(256, lds, trig, u, 8, 1 << s);
+    shuflAndMulw(256, lds, trig, u, 8, 1 << s);
   }
-
   fft8(u);
 
   u32 me = get_local_id(0);
+#if T2_SHUFFLE_WIDTH == 1
+  bar();
+  for (i32 i = 0; i < 8; ++i) { lds[(me + i * 256) / 4 + me % 4 * 512] = u[i]; }
+  bar();
+  for (i32 i = 0; i < 4; ++i) {
+    u[i]   = lds[i * 512       + me];
+    u[i+4] = lds[i * 512 + 256 + me];
+  }
+#else
   for (i32 b = 0; b < 2; ++b) {
     bar();
-    for (i32 i = 0; i < 8; ++i) { lds[(me + i * 256) / 4 + me % 4 * 512] = ((T *) (u + i))[b]; }
+    for (i32 i = 0; i < 8; ++i) { ((local T*)lds)[(me + i * 256) / 4 + me % 4 * 512] = ((T *) (u + i))[b]; }
     bar();
     for (i32 i = 0; i < 4; ++i) {
-      ((T *) (u + i))[b]     = lds[i * 512       + me];
-      ((T *) (u + i + 4))[b] = lds[i * 512 + 256 + me];
+      ((T *) (u + i))[b]     = ((local T*)lds)[i * 512       + me];
+      ((T *) (u + i + 4))[b] = ((local T*)lds)[i * 512 + 256 + me];
     }
   }
+#endif
 
   for (i32 i = 1; i < 4; ++i) {
     u[i]     = mul(u[i],     trig[i * 512       + me]);
@@ -990,6 +1135,50 @@ void fft2K(local T *lds, T2 *u, const global T2 *trig) {
   SWAP(u[5], u[6]);
   SWAP(u[3], u[6]);
 }
+void fft2Kh(local T2 *lds, T2 *u, const global T2 *trig) {
+  UNROLL_HEIGHT_CONTROL
+  for (i32 s = 5; s >= 2; s -= 3) {
+    fft8(u);
+    shuflAndMulh(256, lds, trig, u, 8, 1 << s);
+  }
+  fft8(u);
+
+  u32 me = get_local_id(0);
+#if T2_SHUFFLE_HEIGHT == 1
+  bar();
+  for (i32 i = 0; i < 8; ++i) { lds[(me + i * 256) / 4 + me % 4 * 512] = u[i]; }
+  bar();
+  for (i32 i = 0; i < 4; ++i) {
+    u[i]   = lds[i * 512       + me];
+    u[i+4] = lds[i * 512 + 256 + me];
+  }
+#else
+  for (i32 b = 0; b < 2; ++b) {
+    bar();
+    for (i32 i = 0; i < 8; ++i) { ((local T*)lds)[(me + i * 256) / 4 + me % 4 * 512] = ((T *) (u + i))[b]; }
+    bar();
+    for (i32 i = 0; i < 4; ++i) {
+      ((T *) (u + i))[b]     = ((local T*)lds)[i * 512       + me];
+      ((T *) (u + i + 4))[b] = ((local T*)lds)[i * 512 + 256 + me];
+    }
+  }
+#endif
+
+  for (i32 i = 1; i < 4; ++i) {
+    u[i]     = mul(u[i],     trig[i * 512       + me]);
+    u[i + 4] = mul(u[i + 4], trig[i * 512 + 256 + me]);
+  }
+
+  fft4(u);
+  fft4(u + 4);
+
+  // fix order: interleave u[0:3] and u[4:7], like (u.even, u.odd) = (u.lo, u.hi).
+  SWAP(u[1], u[2]);
+  SWAP(u[1], u[4]);
+  SWAP(u[5], u[6]);
+  SWAP(u[3], u[6]);
+}
+
 
 void read(u32 WG, u32 N, T2 *u, const global T2 *in, u32 base) {
   for (i32 i = 0; i < N; ++i) { u[i] = in[base + i * WG + (u32) get_local_id(0)]; }
@@ -1156,35 +1345,35 @@ KERNEL(256) isNotZero(u32 sizeBytes, global i64 *in, P(bool) outNotZero) {
   }
 }
 
-void fft_WIDTH(local T *lds, T2 *u, Trig trig) {
+void fft_WIDTH(local T2 *lds, T2 *u, Trig trig) {
 #if   WIDTH == 64
-  fft64(lds, u, trig);
+  fft64w(lds, u, trig);
 #elif WIDTH == 256
-  fft256(lds, u, trig);
+  fft256w(lds, u, trig);
 #elif WIDTH == 512
-  fft512(lds, u, trig);
+  fft512w(lds, u, trig);
 #elif WIDTH == 1024
-  fft1K(lds, u, trig);
+  fft1Kw(lds, u, trig);
 #elif WIDTH == 2048
-  fft2K(lds, u, trig);
+  fft2Kw(lds, u, trig);
 #elif WIDTH == 4096
-  fft4K(lds, u, trig);
+  fft4Kw(lds, u, trig);
 #else
 #error unexpected WIDTH.  
 #endif  
 }
 
-void fft_HEIGHT(local T *lds, T2 *u, Trig trig) {
+void fft_HEIGHT(local T2 *lds, T2 *u, Trig trig) {
 #if SMALL_HEIGHT == 64
-  fft64(lds, u, trig);
+  fft64h(lds, u, trig);
 #elif SMALL_HEIGHT == 256
-  fft256(lds, u, trig);
+  fft256h(lds, u, trig);
 #elif SMALL_HEIGHT == 512
-  fft512(lds, u, trig);
+  fft512h(lds, u, trig);
 #elif SMALL_HEIGHT == 1024
-  fft1K(lds, u, trig);
+  fft1Kh(lds, u, trig);
 #elif SMALL_HEIGHT == 2048
-  fft2K(lds, u, trig);
+  fft2Kh(lds, u, trig);
 #else
 #error unexpected SMALL_HEIGHT.
 #endif
@@ -1354,7 +1543,7 @@ void readCarryFusedLine(CP(T2) in, T2 *u, u32 line) {
 
 // Do an fft_WIDTH after a transposeH (which may not have fully transposed data, leading to non-sequential input)
 KERNEL(G_W) fftW(CP(T2) in, P(T2) out, Trig smallTrig) {
-  local T lds[WIDTH];
+  local T2 lds[WIDTH/T2_SHUFFLE_WIDTH];
   T2 u[NW];
 
   u32 g = get_group_id(0);
@@ -1580,7 +1769,7 @@ void readTailFusedLine(CP(T2) in, T2 *u, u32 line, u32 memline) {
 
 // Do an FFT Height after a transposeW (which may not have fully transposed data, leading to non-sequential input)
 KERNEL(G_H) fftHin(CP(T2) in, P(T2) out, Trig smallTrig) {
-  local T lds[SMALL_HEIGHT];
+  local T2 lds[SMALL_HEIGHT/T2_SHUFFLE_HEIGHT];
   T2 u[NH];
 
   u32 g = get_group_id(0);
@@ -1594,7 +1783,7 @@ KERNEL(G_H) fftHin(CP(T2) in, P(T2) out, Trig smallTrig) {
 
 // Do an FFT Height after a pointwise squaring/multiply (data is in sequential order)
 KERNEL(G_H) fftHout(P(T2) io, Trig smallTrig) {
-  local T lds[SMALL_HEIGHT];
+  local T2 lds[SMALL_HEIGHT/T2_SHUFFLE_HEIGHT];
   T2 u[NH];
 
   u32 g = get_group_id(0);
@@ -1607,7 +1796,7 @@ KERNEL(G_H) fftHout(P(T2) io, Trig smallTrig) {
 
 // fftPremul: weight words with "A" (for IBDWT) followed by FFT.
 KERNEL(G_W) fftP(CP(Word2) in, P(T2) out, CP(T2) A, Trig smallTrig) {
-  local T lds[WIDTH];
+  local T2 lds[WIDTH/T2_SHUFFLE_WIDTH];
   T2 u[NW];
 
   u32 g = get_group_id(0);
@@ -1771,7 +1960,7 @@ void middleMul2(T2 *u, u32 g, u32 me) {
 
 void middleShuffle(local T2 *lds, T2 *u, u32 kernel_width, u32 group_size) {
   u32 me = get_local_id(0);
-#ifdef T2_SHUFFLE
+#if T2_SHUFFLE_MIDDLE == 1
   for (i32 i = 0; i < MIDDLE; ++i) {
     bar ();
     lds[(me % group_size) * (kernel_width / group_size) + (me / group_size)] = u[i];
@@ -1779,13 +1968,13 @@ void middleShuffle(local T2 *lds, T2 *u, u32 kernel_width, u32 group_size) {
     u[i] = lds[me];
   }
 #else
-  for (i32 i = 0; i < MIDDLE; ++i) {
-    bar();
-    ((local T*)lds)[(me % group_size) * (kernel_width / group_size) + (me / group_size)] = u[i].x;
-    ((local T*)lds)[kernel_width + (me % group_size) * (kernel_width / group_size) + (me / group_size)] = u[i].y;
-    bar();
-    u[i].x = ((local T*)lds)[me];
-    u[i].y = ((local T*)lds)[kernel_width + me];
+  for (u32 b = 0; b < 2; ++b) {
+    for (i32 i = 0; i < MIDDLE; ++i) {
+      bar();
+      ((local T*)lds)[(me % group_size) * (kernel_width / group_size) + (me / group_size)] = ((T*)(u + i))[b];
+      bar();
+      ((T*)(u + i))[b] = ((local T*)lds)[me];
+    }
   }
 #endif
 }
@@ -1795,7 +1984,7 @@ void middleShuffle(local T2 *lds, T2 *u, u32 kernel_width, u32 group_size) {
 
 #if defined(WORKINGIN)
 KERNEL(256) fftMiddleIn(CP(T2) in, P(T2) out) {
-  local T2 lds[256];
+  local T2 lds[256/T2_SHUFFLE_MIDDLE];
   T2 u[MIDDLE];
   u32 g = get_group_id(0);
   u32 me = get_local_id(0);
@@ -1845,7 +2034,7 @@ KERNEL(256) fftMiddleIn(CP(T2) in, P(T2) out) {
 #elif WORKINGIN1
 
 KERNEL(256) fftMiddleIn(CP(T2) in, P(T2) out) {
-  local T2 lds[256];
+  local T2 lds[256/T2_SHUFFLE_MIDDLE];
   T2 u[MIDDLE];
   u32 g = get_group_id(0);
   u32 me = get_local_id(0);
@@ -1969,7 +2158,7 @@ KERNEL(256) fftMiddleIn(CP(T2) in, P(T2) out) {
 #elif WORKINGIN2
 
 KERNEL(256) fftMiddleIn(CP(T2) in, P(T2) out) {
-  local T2 lds[256];
+  local T2 lds[256/T2_SHUFFLE_MIDDLE];
   T2 u[MIDDLE];
   u32 g = get_group_id(0);
   u32 me = get_local_id(0);
@@ -2026,7 +2215,7 @@ KERNEL(256) fftMiddleIn(CP(T2) in, P(T2) out) {
 #elif WORKINGIN3
 
 KERNEL(256) fftMiddleIn(CP(T2) in, P(T2) out) {
-  local T2 lds[256];
+  local T2 lds[256/T2_SHUFFLE_MIDDLE];
   T2 u[MIDDLE];
   u32 g = get_group_id(0);
   u32 me = get_local_id(0);
@@ -2083,7 +2272,7 @@ KERNEL(256) fftMiddleIn(CP(T2) in, P(T2) out) {
 #elif WORKINGIN4
 
 KERNEL(256) fftMiddleIn(CP(T2) in, P(T2) out) {
-  local T2 lds[256];
+  local T2 lds[256/T2_SHUFFLE_MIDDLE];
   T2 u[MIDDLE];
   u32 g = get_group_id(0);
   u32 me = get_local_id(0);
@@ -2140,7 +2329,7 @@ KERNEL(256) fftMiddleIn(CP(T2) in, P(T2) out) {
 #elif WORKINGIN5
 
 KERNEL(256) fftMiddleIn(CP(T2) in, P(T2) out) {
-  local T2 lds[256];
+  local T2 lds[256/T2_SHUFFLE_MIDDLE];
   T2 u[MIDDLE];
   u32 g = get_group_id(0);
   u32 me = get_local_id(0);
@@ -2225,7 +2414,7 @@ KERNEL(256) fftMiddleOut(P(T2) in, P(T2) out) {
 #elif defined(WORKINGOUT)
 
 KERNEL(256) fftMiddleOut(P(T2) in, P(T2) out) {
-  local T2 lds[256];
+  local T2 lds[256/T2_SHUFFLE_MIDDLE];
   T2 u[MIDDLE];
   u32 g = get_group_id(0);
   u32 me = get_local_id(0);
@@ -2272,7 +2461,7 @@ KERNEL(256) fftMiddleOut(P(T2) in, P(T2) out) {
 #elif WORKINGOUT0
 
 KERNEL(256) fftMiddleOut(P(T2) in, P(T2) out) {
-  local T2 lds[256];
+  local T2 lds[256/T2_SHUFFLE_MIDDLE];
   T2 u[MIDDLE];
   u32 g = get_group_id(0);
   u32 me = get_local_id(0);
@@ -2330,7 +2519,7 @@ KERNEL(256) fftMiddleOut(P(T2) in, P(T2) out) {
 #elif WORKINGOUT1
 
 KERNEL(256) fftMiddleOut(P(T2) in, P(T2) out) {
-  local T2 lds[256];
+  local T2 lds[256/T2_SHUFFLE_MIDDLE];
   T2 u[MIDDLE];
   u32 g = get_group_id(0);
   u32 me = get_local_id(0);
@@ -2453,7 +2642,7 @@ KERNEL(256) fftMiddleOut(P(T2) in, P(T2) out) {
 #elif WORKINGOUT2
 
 KERNEL(256) fftMiddleOut(P(T2) in, P(T2) out) {
-  local T2 lds[256];
+  local T2 lds[256/T2_SHUFFLE_MIDDLE];
   T2 u[MIDDLE];
   u32 g = get_group_id(0);
   u32 me = get_local_id(0);
@@ -2510,7 +2699,7 @@ KERNEL(256) fftMiddleOut(P(T2) in, P(T2) out) {
 #elif WORKINGOUT3
 
 KERNEL(256) fftMiddleOut(P(T2) in, P(T2) out) {
-  local T2 lds[256];
+  local T2 lds[256/T2_SHUFFLE_MIDDLE];
   T2 u[MIDDLE];
   u32 g = get_group_id(0);
   u32 me = get_local_id(0);
@@ -2567,7 +2756,7 @@ KERNEL(256) fftMiddleOut(P(T2) in, P(T2) out) {
 #elif WORKINGOUT4
 
 KERNEL(256) fftMiddleOut(P(T2) in, P(T2) out) {
-  local T2 lds[256];
+  local T2 lds[256/T2_SHUFFLE_MIDDLE];
   T2 u[MIDDLE];
   u32 g = get_group_id(0);
   u32 me = get_local_id(0);
@@ -2624,7 +2813,7 @@ KERNEL(256) fftMiddleOut(P(T2) in, P(T2) out) {
 #elif WORKINGOUT5
 
 KERNEL(256) fftMiddleOut(P(T2) in, P(T2) out) {
-  local T2 lds[256];
+  local T2 lds[256/T2_SHUFFLE_MIDDLE];
   T2 u[MIDDLE];
   u32 g = get_group_id(0);
   u32 me = get_local_id(0);
@@ -2757,7 +2946,7 @@ void acquire() {
 // __attribute__((amdgpu_num_vgpr(64)))
 KERNEL(G_W) carryFused(CP(T2) in, P(T2) out, P(Carry) carryShuttle, P(u32) ready, Trig smallTrig,
                        CP(u32) bits, CP(T2) groupWeights, CP(T2) threadWeights) {
-  local T lds[WIDTH];
+  local T2 lds[WIDTH/T2_SHUFFLE_WIDTH];
   u32 gr = get_group_id(0);
   u32 me = get_local_id(0);
 
@@ -2836,7 +3025,7 @@ KERNEL(G_W) carryFused(CP(T2) in, P(T2) out, P(Carry) carryShuttle, P(u32) ready
 // copy of carryFused() above, with the only difference the mul-by-3 in unweightAndCarry().
 KERNEL(G_W) carryFusedMul(CP(T2) in, P(T2) out, P(Carry) carryShuttle, P(u32) ready, Trig smallTrig,
                           CP(u32) bits, CP(T2) groupWeights, CP(T2) threadWeights) {
-  local T lds[WIDTH];
+  local T2 lds[WIDTH/T2_SHUFFLE_WIDTH];
   u32 gr = get_group_id(0);
   u32 me = get_local_id(0);
 
@@ -3066,8 +3255,7 @@ KERNEL(SMALL_HEIGHT / 2 / 4) multiply(P(T2) io, CP(T2) in) {
 
 // tailFused below
 
-void reverse(u32 WG, local T *rawLds, T2 *u, bool bump) {
-  local T2 *lds = (local T2 *)rawLds;
+void reverse(u32 WG, local T2 *lds, T2 *u, bool bump) {
   u32 me = get_local_id(0);
   u32 revMe = WG - 1 - me + bump;
   
@@ -3100,32 +3288,36 @@ void reverse(u32 WG, local T *rawLds, T2 *u, bool bump) {
 			  ds_permute_b32 %2, %3, %2\n" : "+v" (b) : "v" (as_int2(b).x), "v" (as_int2(b).y), "v" (reverse_lane_ids)); }
 #define reverse_t2(a) { reverse_t (a.x); reverse_t (a.y); }
 
-void reverseLine(u32 WG, local T *lds, T2 *u) {
+void reverseLine(u32 WG, local T2 *lds, T2 *u) {
   u32 me = get_local_id(0);			// Lane ID - in the range 0-63
   u32 reverse_lane_ids = (WG - 1 - me) * 4;	// Reverse of the lane ID * 4 -- for ds_permute_b32
 
   // reverse each T2 value
-  for (i32 i = 0; i < NH; ++i) {
-	reverse_t2 (u[i]);
-  }
+  for (i32 i = 0; i < NH; ++i) { reverse_t2 (u[i]); }
 //  __asm volatile ( "s_waitcnt lgkmcnt(0)\n");\
 
   // Now reverse the NH values
-  for (i32 i = 0; i < NH/2; ++i)
-	SWAP (u[i], u[NH-1-i]);
+  for (i32 i = 0; i < NH/2; ++i) { SWAP (u[i], u[NH-1-i]); }
 }
 
 #else
 
-void reverseLine(u32 WG, local T *lds, T2 *u) {
+void reverseLine(u32 WG, local T2 *lds, T2 *u) {
   u32 me = get_local_id(0);
   u32 revMe = WG - 1 - me;
+#if T2_SHUFFLE_REVERSELINE == 1
+  bar();
+  for (i32 i = 0; i < NH; ++i) { lds[i * WG + revMe] = u[(NH - 1) - i]; }
+  bar();
+  for (i32 i = 0; i < NH; ++i) { u[i] = lds[i * WG + me]; }
+#else
   for (i32 b = 0; b < 2; ++b) {
     bar();
-    for (i32 i = 0; i < NH; ++i) { lds[i * WG + revMe] = ((T *) (u + ((NH - 1) - i)))[b]; }  
+    for (i32 i = 0; i < NH; ++i) { ((local T*)lds)[i * WG + revMe] = ((T *) (u + ((NH - 1) - i)))[b]; }  
     bar();
-    for (i32 i = 0; i < NH; ++i) { ((T *) (u + i))[b] = lds[i * WG + me]; }
+    for (i32 i = 0; i < NH; ++i) { ((T *) (u + i))[b] = ((local T*)lds)[i * WG + me]; }
   }
+#endif
 }
 
 #endif
@@ -3345,8 +3537,7 @@ void pairMul(u32 N, T2 *u, T2 *v, T2 *p, T2 *q, T2 base, bool special) {
 
 // equivalent to: fftHin, multiply, fftHout.
 KERNEL(G_H) tailFused(CP(T2) in, P(T2) out, Trig smallTrig) {
-  local T2 rawLds[(SMALL_HEIGHT+1)/2];
-  local T *lds = (local T *)rawLds;
+  local T2 lds[SMALL_HEIGHT/T2_SHUFFLE_TAILFUSED];
   T2 u[NH], v[NH];
 
   u32 W = SMALL_HEIGHT;
@@ -3388,8 +3579,7 @@ KERNEL(G_H) tailFused(CP(T2) in, P(T2) out, Trig smallTrig) {
 
 // equivalent to: fftHin(io, out), multiply(out, a - b), fftH(out)
 KERNEL(G_H) tailFusedMulDelta(CP(T2) in, P(T2) out, CP(T2) a, CP(T2) b, Trig smallTrig) {
-  local T2 rawLds[(SMALL_HEIGHT+1)/2];
-  local T *lds = (local T *)rawLds;
+  local T2 lds[SMALL_HEIGHT/T2_SHUFFLE_TAILFUSED];
   T2 u[NH], v[NH];
   T2 p[NH], q[NH];
 

--- a/gpuowl.cl
+++ b/gpuowl.cl
@@ -91,14 +91,13 @@ typedef ulong u64;
 // Consequently, we have separate defines so we can selectively do T2 shuffling.  For now we assume the original code
 // that does 64x64 shuffles uses so much local memory that we'll not offer a T2 shuffle in there.
 //
-// For a 5M FFT on a Radeon VII, the best combination is T2_SHUFFLE_MIDDLE,T2_SHUFFLE_REVERSELINE, but
-// not T2_SHUFFLE_WIDTH,T2_SHUFFLE_HEIGHT.  This may indicate that any speed differences are due to vagaries of
+// For a 5M FFT on a Radeon VII, the best combination is T2_SHUFFLE_REVERSELINE, but not T2_SHUFFLE_MIDDLE,
+// T2_SHUFFLE_WIDTH,T2_SHUFFLE_HEIGHT.  This may indicate that speed differences are due to vagaries of
 // the ROCm optimizer rather than an inherit benefit of T2 vs. T shuffles.  The AMD OpenCL optimization manual says
 // T shuffles should give the best performance.
 
 #if !defined(T2_SHUFFLE) && !defined(NO_T2_SHUFFLE) && !defined(T2_SHUFFLE_WIDTH) && !defined(T2_SHUFFLE_MIDDLE) && !defined(T2_SHUFFLE_HEIGHT) && !defined(T2_SHUFFLE_REVERSELINE)
 #ifdef AMDGPU
-#define T2_SHUFFLE_MIDDLE
 #define T2_SHUFFLE_REVERSELINE
 #endif
 #endif
@@ -1382,13 +1381,13 @@ void fft_HEIGHT(local T2 *lds, T2 *u, Trig trig) {
 // Read a line for carryFused or FFTW
 void readCarryFusedLine(CP(T2) in, T2 *u, u32 line) {
 
-// My 5M timings (in us).	WorkingOut0 is fftMiddleOut 128 + carryFused 372
-//				WorkingOut1 is fftMiddleOut 129 + carryFused 305
-//				WorkingOut1a is fftMiddleOut 128 + carryFused 305
-//				WorkingOut2 is fftMiddleOut 221 + carryFused 300
-//				WorkingOut3 is fftMiddleOut 130 + carryFused 291
-//				WorkingOut4 is fftMiddleOut 167 + carryFused 285
-//				WorkingOut5 is fftMiddleOut 120 + carryFused 311
+// My 5M timings (in us).	WorkingOut0 is fftMiddleOut 128 + carryFused 372 (T2_SHUFFLE_MIDDLE)	133/369 (NO_T2_SHUFFLE)
+//				WorkingOut1 is fftMiddleOut 129 + carryFused 305			133/301
+//				WorkingOut1a is fftMiddleOut 128 + carryFused 305			128/305
+//				WorkingOut2 is fftMiddleOut 221 + carryFused 300			223/298
+//				WorkingOut3 is fftMiddleOut 130 + carryFused 291			127/287
+//				WorkingOut4 is fftMiddleOut 167 + carryFused 285			169/280
+//				WorkingOut5 is fftMiddleOut 120 + carryFused 311			111/309
 // For comparison non-merged carryFused is 297 us
 #if !defined(WORKINGOUT) && !defined(WORKINGOUT0) && !defined(WORKINGOUT1) && !defined(WORKINGOUT1A) && !defined(WORKINGOUT2) && !defined(WORKINGOUT3) && !defined(WORKINGOUT4) && !defined(WORKINGOUT5)
 #if G_W >= 32
@@ -1556,11 +1555,11 @@ KERNEL(G_W) fftW(CP(T2) in, P(T2) out, Trig smallTrig) {
 // Read a line for tailFused or fftHin
 void readTailFusedLine(CP(T2) in, T2 *u, u32 line, u32 memline) {
 
-// My 5M timings (in us).	WorkingIn1 is fftMiddleIn 144 + tailFused 191
+// My 5M timings (in us).	WorkingIn1 is fftMiddleIn 144 + tailFused 191 (T2_SHUFFLE_MIDDLE && T2_SHUFFLE_REVERSELINE)
 //				WorkingIn1a is fftMiddleIn 141 + tailFused 191
 //				WorkingIn2 is fftMiddleIn 133 + tailFused 217
 //				WorkingIn3 is fftMiddleIn 138 + tailFused 192
-//				WorkingIn4 is fftMiddleIn 207 + tailFused 189
+//				WorkingIn4 is fftMiddleIn 207 + tailFused 189		
 //				WorkingIn5 is fftMiddleIn 134 + tailFused 194
 // For comparison non-merged tailFused is 192 us
 #if !defined(WORKINGIN) && !defined(WORKINGIN1) && !defined(WORKINGIN1A) && !defined(WORKINGIN2) && !defined(WORKINGIN3) && !defined(WORKINGIN4) && !defined(WORKINGIN5)

--- a/gpuowl.cl
+++ b/gpuowl.cl
@@ -1382,19 +1382,17 @@ void fft_HEIGHT(local T2 *lds, T2 *u, Trig trig) {
 // Read a line for carryFused or FFTW
 void readCarryFusedLine(CP(T2) in, T2 *u, u32 line) {
 
-// My 5M timings (in us).	WorkingOut0 is fftMiddleOut 128 + carryFused 449
-//				WorkingOut1 is fftMiddleOut 128 + carryFused 372
-//				WorkingOut1a is fftMiddleOut 128 + carryFused 372
-//				WorkingOut2 is fftMiddleOut 221 + carryFused 372
-//				WorkingOut3 is fftMiddleOut 129 + carryFused 352
-//				WorkingOut4 is fftMiddleOut 167 + carryFused 345
-//				WorkingOut5 is fftMiddleOut 120 + carryFused 398
-// For comparison non-merged carryFused is 343 us
+// My 5M timings (in us).	WorkingOut0 is fftMiddleOut 128 + carryFused 372
+//				WorkingOut1 is fftMiddleOut 129 + carryFused 305
+//				WorkingOut1a is fftMiddleOut 128 + carryFused 305
+//				WorkingOut2 is fftMiddleOut 221 + carryFused 300
+//				WorkingOut3 is fftMiddleOut 130 + carryFused 291
+//				WorkingOut4 is fftMiddleOut 167 + carryFused 285
+//				WorkingOut5 is fftMiddleOut 120 + carryFused 311
+// For comparison non-merged carryFused is 297 us
 #if !defined(WORKINGOUT) && !defined(WORKINGOUT0) && !defined(WORKINGOUT1) && !defined(WORKINGOUT1A) && !defined(WORKINGOUT2) && !defined(WORKINGOUT3) && !defined(WORKINGOUT4) && !defined(WORKINGOUT5)
 #if G_W >= 32
 #define WORKINGOUT3 1
-#elif G_W >= 16
-#define WORKINGOUT1A 1
 #elif G_W >= 8
 #define WORKINGOUT5 1
 #endif
@@ -1558,21 +1556,15 @@ KERNEL(G_W) fftW(CP(T2) in, P(T2) out, Trig smallTrig) {
 // Read a line for tailFused or fftHin
 void readTailFusedLine(CP(T2) in, T2 *u, u32 line, u32 memline) {
 
-// My 5M timings (in us).	WorkingIn1 is fftMiddleIn 139 + tailFused 196
-//				WorkingIn1a is fftMiddleIn 138 + tailFused 196
-//				WorkingIn2 is fftMiddleIn 130 + tailFused 214
-//				WorkingIn3 is fftMiddleIn 135 + tailFused 196
-//				WorkingIn4 is fftMiddleIn 204 + tailFused 195
-//				WorkingIn5 is fftMiddleIn 130 + tailFused 200
+// My 5M timings (in us).	WorkingIn1 is fftMiddleIn 144 + tailFused 191
+//				WorkingIn1a is fftMiddleIn 141 + tailFused 191
+//				WorkingIn2 is fftMiddleIn 133 + tailFused 217
+//				WorkingIn3 is fftMiddleIn 138 + tailFused 192
+//				WorkingIn4 is fftMiddleIn 207 + tailFused 189
+//				WorkingIn5 is fftMiddleIn 134 + tailFused 194
 // For comparison non-merged tailFused is 192 us
 #if !defined(WORKINGIN) && !defined(WORKINGIN1) && !defined(WORKINGIN1A) && !defined(WORKINGIN2) && !defined(WORKINGIN3) && !defined(WORKINGIN4) && !defined(WORKINGIN5)
-#if G_H >= 32
-#define WORKINGIN3 1
-#elif G_H >= 16
-#define WORKINGIN1A 1
-#elif G_H >= 8
 #define WORKINGIN5 1
-#endif
 #endif
 
 #if MIDDLE == 1 || !defined(MERGED_MIDDLE) || defined(WORKINGIN)


### PR DESCRIPTION
These changes helped ROCm 2.9 get the register count for fftMiddleIn down below 83 for an increase in occupancy.  Saves a couple microseconds.

Git seems can't merge automatically and the diff shows a zillion changes.  In reality there are only a handful of changes.