### PR TITLE
 Best kcos implementation, ROCM bug worked around

### DIFF
--- a/FFTConfig.h
+++ b/FFTConfig.h
@@ -18,6 +18,7 @@ struct FFTConfig {
   u32 maxExp = 0;
 
   static u32 getMaxExp(u32 fftSize, bool isPm1);
+  static u32 getMaxCarry32(u32 fftSize, u32 exponent);
 
   static std::vector<FFTConfig> genConfigs(bool isPm1);
 

--- a/Gpu.cpp
+++ b/Gpu.cpp
@@ -352,9 +352,7 @@ unique_ptr<Gpu> Gpu::make(u32 E, const Args &args, bool isPm1) {
     throw "FFT size too large";
   }
     
-  bool useLongCarry = (bitsPerWord < 14.5f)
-    || (args.carry == Args::CARRY_LONG)
-    || (args.carry == Args::CARRY_AUTO && WIDTH >= 2048);
+  bool useLongCarry = (bitsPerWord < 14.5f) || (args.carry == Args::CARRY_LONG);
 
   if (useLongCarry) { log("using long carry kernels\n"); }
 

--- a/gpuowl.cl
+++ b/gpuowl.cl
@@ -30,8 +30,8 @@ NEWEST_FFT5
 NEW_FFT10 <default>
 OLD_FFT10
 
-CARRY32 <AMD default for PRP>
-CARRY64 <nVidia default>, <AMD default for PM1>
+CARRY32 <AMD default for PRP when appropriate>
+CARRY64 <nVidia default>, <AMD default for PM1 when appropriate>
 
 CARRYM32
 CARRYM64 <default>
@@ -108,7 +108,7 @@ G_H        "group height"
 #endif
 
 #if !CARRY32 && !CARRY64
-#if AMDGPU && !PM1
+#if AMDGPU
 #define CARRY32 1
 #endif
 #endif


### PR DESCRIPTION
Finally worked around Rocm bug with the best kcos implementation.  One extra useless if statement did the trick.  Nvidia users will get the unadulterated kcos code.
Eliminated first barrier in MiddleIn/MiddleOut.  The rocm optimizer was sometimes moving this so far forward in the instruction stream that memory loads did not have a chance to complete.  This is why the previous kcos implementation was faster despite generating a ton of extra ops.
Changed MiddleMul to reduce chain length by one -- minor improvement to accuracy.