### PR TITLE
Create remove_checkpoints_by_size.sh

### DIFF
--- a/remove_checkpoints_by_size.sh
+++ b/remove_checkpoints_by_size.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# This one-liner is still valid, however you have to pass the subdirectory with checkpoint files as first argument;
+# In the subdirectory there are two checkpoint files: *.owl and *-old.owl
+# 
+
+set -o xtrace
+
+find $1 -name '*.owl' -a -size 0 -exec rm -v {} + | tee -a ./removed_checkpoints.log


### PR DESCRIPTION
After a blackout you may find yourself with invalid savefiles that make gpuowl fail to start working. On blackout, savefiles are not closed, and are truncated to length 0 on reboot.
This simple command lets you remove all the *bad* savefiles in one shot, it is useful if you have a system with multiple gpus.
You can search in multiple directories like this: ./remove_checkpoints_by_size.sh 'dir1 dir2 dir3 ...'