### PR TITLE
Update and move remove_checkpoints_by_size.sh

### DIFF
--- a/tools/remove_checkpoints_by_size.sh
+++ b/tools/remove_checkpoints_by_size.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This one-liner is still valid, however you have to pass the subdirectory with checkpoint files as first argument;
 # In the subdirectory there are two checkpoint files: *.owl and *-old.owl


### PR DESCRIPTION
This change ensures that bash is always found even on systems that install it on different directories.