### PR TITLE
Small changes to build on Cygwin under MSWindows10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ cuda/
 cmake-build-*/
 .idea
 .sconsign.dblite
+.d
+gpuowl-expanded.cl

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ cmake-build-*/
 .sconsign.dblite
 .d
 gpuowl-expanded.cl
+gpuowl.exe

--- a/AMD3.0
+++ b/AMD3.0
@@ -1,1 +1,0 @@
-/cygdrive/c/Program Files (x86)/AMD APP SDK/3.0

--- a/AMD3.0
+++ b/AMD3.0
@@ -1,0 +1,1 @@
+/cygdrive/c/Program Files (x86)/AMD APP SDK/3.0

--- a/Queue.h
+++ b/Queue.h
@@ -63,7 +63,13 @@ public:
   void finish() {
     if (cudaYield) {
       flush();
-      while (!allEventsCompleted()) { usleep(500); }
+      while (!allEventsCompleted()) {
+#if defined(__CYGWIN__)
+	sleep(1);
+#else
+	usleep(500);
+#endif
+      }
     }
     
     ::finish(get());


### PR DESCRIPTION
Queue.h - an #fidef __CYGWIN__ to use sleep() instead of usleep().
.gitignore - add .d and a couple of files created during make.
AMD3.0 - a soft link to a common place for OpenCL from AMD.