### PR TITLE
Fix std::optional not found

### DIFF
--- a/B1Accumulator.h
+++ b/B1Accumulator.h
@@ -6,6 +6,7 @@
 #include "Memlock.h"
 #include "common.h"
 
+#include <optional>
 #include <cassert>
 
 class Gpu;


### PR DESCRIPTION
When compiling on GCC 11.1 compilation throws 
`B1Accumulator.h:31:8: error: ‘optional’ in namespace ‘std’ does not name a template type`