### PR TITLE
Added support for the `PRPDC=` prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,12 @@ are also used to speed up computation, e.g. the “Irrational Base Discrete Weig
 ## `worktodo.txt`
 The lines in `worktodo.txt` must be of one of these forms:
 * `70100200`
+* `PRP=1,2,77936867,-1,75,0`
+* `PRP=N/A,1,2,77936867,-1,75,0`
 * `PRP=FCECE568118E4626AB85ED36A9CC8D4F,1,2,77936867,-1,75,0`
 
-The first form indicates just the exponent to test, while the form starting with PRP indicates both the
-exponent and the assignment ID (AID) from PrimeNet.
+The first form indicates just the exponent to test, while the form starting with `PRP=` indicates the
+exponent and optionally the assignment ID (AID) from PrimeNet. The `PRPDC=` prefix can be used instead for PRP DC assignments.
 
 ## Usage
 * Get "PRP smallest available first time tests" assignments from GIMPS Manual Testing ( http://mersenne.org/ ).

--- a/Worktodo.cpp
+++ b/Worktodo.cpp
@@ -33,13 +33,17 @@ std::optional<Task> parse(const std::string& line) {
   if(sscanf(tail.c_str(), "%11[a-zA-Z]=%n", kindStr, &pos) == 1) {
     string kind = kindStr;
     tail = tail.substr(pos);
-    if (kind == "PRP") {
+    if (kind == "PRP" or kind == "PRPDC") {
       if (tail.find('"') != string::npos) {
         log("GpuOwl does not support PRP-CF!\n");
       } else {
         char AIDStr[64] = {0};
-        if (sscanf(tail.c_str(), "%32[0-9a-fA-FN/],1,2,%u,-1,%u,%u", AIDStr, &exp, &bitLo, &wantsPm1) == 4
-            || sscanf(tail.c_str(), "%32[0-9a-fA-FN/],%u", AIDStr, &exp) == 2
+        if (sscanf(tail.c_str(), "%32[0-9a-fA-F],1,2,%u,-1,%u,%u", AIDStr, &exp, &bitLo, &wantsPm1) == 4
+            || (AIDStr[0]=0, sscanf(tail.c_str(), "N/A,1,2,%u,-1,%u,%u", &exp, &bitLo, &wantsPm1) == 3)
+            || (AIDStr[0]=0, sscanf(tail.c_str(), "1,2,%u,-1,%u,%u", &exp, &bitLo, &wantsPm1) == 3)
+            || sscanf(tail.c_str(), "%32[0-9a-fA-F],%u,%u,%u", AIDStr, &exp, &bitLo, &wantsPm1) == 4
+            || (AIDStr[0]=0, sscanf(tail.c_str(), "N/A,%u,%u,%u", &exp, &bitLo, &wantsPm1) == 3)
+            || (AIDStr[0]=0, sscanf(tail.c_str(), "%u,%u,%u", &exp, &bitLo, &wantsPm1) == 3)
             || (AIDStr[0]=0, sscanf(tail.c_str(), "%u", &exp)) == 1) {
           string AID = AIDStr;
           if (AID == "N/A" || AID == "0") { AID = ""; }


### PR DESCRIPTION
* Added support for the `PRPDC=` prefix for PRP DC assignments, for consistency with Prime95/MPrime and Mlucas.
    * This is needed for our (@Danc2050 and I's) PrimeNet script (see [here](https://www.mersenneforum.org/showthread.php?p=591663#post591663)).
    * Note that this does _not_ add full support for PRP DC assignments, which would require checking the base and residue type.
* Improved parsing of the assignment ID by separating the `N/A` case.
* Added support for PRP assignments without an assignment ID, for consistency with Prime95/MPrime and Mlucas.
    * This is needed for our PrimeNet script to be able support reserving individual exponents (see [here](https://www.mersenneforum.org/showthread.php?p=592793#post592793)).

I kept support for the LL assignment format, as I did not want to remove any functionality, but I suspect that could be removed...

@preda - If you would accept it, I would be happy to make another PR for your v6 branch with these same changes, as our PrimeNet script also supports GpuOwl v6.11.