### PR TITLE
Added support for the `PRPDC=` prefix to v6 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Linux
 
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ (matrix.os == 'ubuntu-18.04' && matrix.cxx == 'g++') || matrix.cxx == 'clang++' }}
+    continue-on-error: ${{ matrix.os == 'ubuntu-18.04' && matrix.cxx == 'g++' }}
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
@@ -31,7 +31,6 @@ jobs:
       run: |
         sed -i 's/<filesystem>/<experimental\/filesystem>/' *.h *.cpp
         sed -i 's/std::filesystem/std::experimental::filesystem/' *.h *.cpp
-        sed -i 's/assert(false);/abort();/' Pm1Plan.cpp
     - name: Script
       run: |
         make -j "$(nproc)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '0 0 1 * *'
+
+jobs:
+  Linux:
+    name: Linux
+
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ (matrix.os == 'ubuntu-18.04' && matrix.cxx == 'g++') || matrix.cxx == 'clang++' }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+        cxx: [g++, clang++]
+      fail-fast: false
+    env:
+      CXX: ${{ matrix.cxx }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install
+      run: |
+        sudo apt-get -yqq update
+        sudo apt-get -yqq install cppcheck ocl-icd-opencl-dev
+        $CXX --version
+    - name: Before script
+      if: ${{ matrix.os == 'ubuntu-18.04' && matrix.cxx == 'g++' }}
+      run: |
+        sed -i 's/<filesystem>/<experimental\/filesystem>/' *.h *.cpp
+        sed -i 's/std::filesystem/std::experimental::filesystem/' *.h *.cpp
+        sed -i 's/assert(false);/abort();/' Pm1Plan.cpp
+    - name: Script
+      run: |
+        make -j "$(nproc)"
+        ./gpuowl -h
+    - uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: ${{ matrix.os }}_${{ matrix.cxx }}_gpuowl
+        path: ${{ github.workspace }}
+    - name: Cppcheck
+      run: cppcheck --enable=all --force .
+    - name: ShellCheck
+      run: bash -c 'shopt -s globstar; shellcheck -s bash **/*.sh || true'
+
+  Windows:
+    name: Windows
+
+    runs-on: windows-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        cxx: [g++, clang++]
+      fail-fast: false
+    env:
+      CXX: ${{ matrix.cxx }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Script
+      run: |
+        make gpuowl-win.exe
+        .\gpuowl-win.exe -h
+    - uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: win_${{ matrix.cxx }}_gpuowl
+        path: ${{ github.workspace }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
     before_script:
       - sed -i 's/<filesystem>/<experimental\/filesystem>/' *.h *.cpp
       - sed -i 's/std::filesystem/std::experimental::filesystem/' *.h *.cpp
-      - sed -i 's/assert(false);/abort();/' Pm1Plan.cpp
   - name: "Ubuntu 18.04 (clang)"
     os: linux
     dist: bionic
@@ -40,7 +39,6 @@ matrix:
   - compiler: gcc
     os: linux
     dist: bionic
-  - compiler: clang
   - os: windows
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+language: cpp
+
+matrix:
+  include:
+  - name: "Ubuntu 18.04 (gcc)"
+    os: linux
+    dist: bionic
+    compiler: gcc
+    virt: vm
+    before_script:
+      - sed -i 's/<filesystem>/<experimental\/filesystem>/' *.h *.cpp
+      - sed -i 's/std::filesystem/std::experimental::filesystem/' *.h *.cpp
+      - sed -i 's/assert(false);/abort();/' Pm1Plan.cpp
+  - name: "Ubuntu 18.04 (clang)"
+    os: linux
+    dist: bionic
+    compiler: clang
+    virt: vm
+    before_script:
+      - sed -i 's/<filesystem>/<experimental\/filesystem>/' *.h *.cpp
+      - sed -i 's/std::filesystem/std::experimental::filesystem/' *.h *.cpp
+  - name: "Ubuntu 20.04 (gcc)"
+    os: linux
+    dist: focal
+    compiler: gcc
+    virt: vm
+  - name: "Ubuntu 20.04 (clang)"
+    os: linux
+    dist: focal
+    compiler: clang
+    virt: vm
+  - name: "Windows"
+    os: windows
+    install: choco install python3 --version=3.8.8
+    env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
+    script:
+      - mingw32-make gpuowl-win.exe
+      - ./gpuowl-win.exe -h
+  allow_failures:
+  - compiler: gcc
+    os: linux
+    dist: bionic
+  - compiler: clang
+  - os: windows
+
+install:
+  - sudo apt-get -yqq update
+  - sudo apt-get -yqq install cppcheck ocl-icd-opencl-dev
+script:
+  - make -j "$(nproc)"
+  - ./gpuowl -h
+  - cppcheck --enable=all --force .
+  - bash -c 'shopt -s globstar; shellcheck -s bash **/*.sh || true'
+

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-CXXFLAGS = -Wall -O2 -std=c++17
+CXXFLAGS = -Wall -g -O3 -std=c++17
 
 LIBPATH = -L/opt/rocm-3.3.0/opencl/lib/x86_64 -L/opt/rocm-3.1.0/opencl/lib/x86_64 -L/opt/rocm/opencl/lib/x86_64 -L/opt/amdgpu-pro/lib/x86_64-linux-gnu -L.
 
 LDFLAGS = -lstdc++fs -lOpenCL -lgmp -pthread ${LIBPATH}
 
-LINK = $(CXX) -o $@ ${OBJS} ${LDFLAGS}
+LINK = $(CXX) $(CXXFLAGS) -o $@ ${OBJS} ${LDFLAGS}
 
 SRCS = Pm1Plan.cpp GmpUtil.cpp Worktodo.cpp common.cpp main.cpp Gpu.cpp clwrap.cpp Task.cpp checkpoint.cpp timeutil.cpp Args.cpp state.cpp Signal.cpp FFTConfig.cpp AllocTrac.cpp gpuowl-wrap.cpp sha3.cpp md5.cpp
 OBJS = $(SRCS:%.cpp=%.o)
@@ -39,7 +39,7 @@ version.inc: FORCE
 	echo Version: `cat version.inc`
 
 gpuowl-expanded.cl: gpuowl.cl
-	./tools/expand.py < gpuowl.cl > gpuowl-expanded.cl
+	python3 tools/expand.py < gpuowl.cl > gpuowl-expanded.cl
 
 gpuowl-wrap.cpp: gpuowl-expanded.cl head.txt tail.txt
 	cat head.txt gpuowl-expanded.cl tail.txt > gpuowl-wrap.cpp

--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ are also used to speed up computation, e.g. the "Irrational Base Discrete Weight
 
 
 ## Files used by gpuOwl
-* worktodo.txt : contains exponents to test, one entry per line
-* results.txt : contains the results
-* N.owl : the most recent checkpoint for exponent <N>; will resume from here
-* N-prev.owl : the previous checkpoint, to be used if N.ll is lost or corrupted
-* N.iteration.owl : a persistent checkpoint at the given iteration
+* `worktodo.txt` : contains exponents to test, one entry per line
+* `results.txt` : contains the results
+* `N.owl` : the most recent checkpoint for exponent <N>; will resume from here
+* `N-prev.owl` : the previous checkpoint, to be used if N.ll is lost or corrupted
+* `N.iteration.owl` : a persistent checkpoint at the given iteration
 
-## worktodo.txt
-The lines in worktodo.txt must be of one of these forms:
-* 70100200
-* PRP=FCECE568118E4626AB85ED36A9CC8D4F,1,2,77936867,-1,75,0
+## `worktodo.txt`
+The lines in `worktodo.txt` must be of one of these forms:
+* `70100200`
+* `PRP=FCECE568118E4626AB85ED36A9CC8D4F,1,2,77936867,-1,75,0`
 
 The first form indicates just the exponent to test, while the form starting with PRP indicates both the
 exponent and the assignment ID (AID) from PrimeNet.
@@ -128,7 +128,7 @@ Simply start GpuOwl with any valid exponent, and the built-in error checking kic
 -prp <exponent>    : run a single PRP test and exit, ignoring worktodo.txt
 -pm1 <exponent>    : run a single P-1 test and exit, ignoring worktodo.txt
 -ll <exponent>     : run a single LL test and exit, ignoring worktodo.txt
--verify <file>|<exponent> : verify PRP-proof contained in <file> or in the folder <exponent>/
+-verify <file>     : verify PRP-proof contained in <file>
 -proof <power>     : Valid <power> values are 6 to 9.
                      By default a proof of power 8 is generated, using 3GB of temporary disk space for a 100M exponent.
                      A lower power reduces disk space requirements but increases the verification cost.
@@ -146,11 +146,13 @@ Simply start GpuOwl with any valid exponent, and the built-in error checking kic
 ```
 Device numbers start at zero.
 
-## Primenet.py Arguments
--h, --help            show this help message and exit\
--u USERNAME           Primenet user name\
--p PASSWORD           Primenet password\
--t TIMEOUT            Seconds to sleep between updates\
---dirs DIR \[DIR ...\]  GpuOwl directories to scan\
---tasks NTASKS        Number of tasks to fetch ahead\
--w \{PRP,PM1,LL_DC,PRP_DC,PRP_WORLD_RECORD,PRP_100M\}   GIMPS work type
+## `Primenet.py` Arguments
+```
+-h, --help            show this help message and exit
+-u USERNAME           Primenet user name
+-p PASSWORD           Primenet password
+-t TIMEOUT            Seconds to sleep between updates
+--dirs DIR [DIR ...]  GpuOwl directories to scan
+--tasks NTASKS        Number of tasks to fetch ahead
+-w {PRP,PM1,LL_DC,PRP_DC,PRP_WORLD_RECORD,PRP_100M}   GIMPS work type
+```

--- a/Task.h
+++ b/Task.h
@@ -38,7 +38,7 @@ struct Task {
   void writeResultLL(const Args&,  bool isPrime, u64 res64, u32 fftSize) const;
   void writeResultPM1(const Args&, const std::string& factor, u32 fftSize, bool didStage2) const;
 
-  string kindStr() const { return kind == PRP ? "PRP" : (kind == PM1 ? "PFactor" : "LL"); }
+  string kindStr() const { return kind == PRP ? "PRP" : (kind == PM1 ? "PFactor" : "DoubleCheck"); }
   
   operator string() const {
     string prefix;
@@ -47,7 +47,7 @@ struct Task {
       snprintf(buf, sizeof(buf), "B1=%u,B2=%u;", B1, B2);
       prefix = buf;
     }
-    snprintf(buf, sizeof(buf), "%s=%s,1,2,%u,-1,%u,%u", kindStr().c_str(), AID.empty() ? "N/A" : AID.c_str(), exponent, bitLo, wantsPm1);
+    snprintf(buf, sizeof(buf), kind == LL ? "%s=%s,%u,%u,%u" : "%s=%s,1,2,%u,-1,%u,%u", kindStr().c_str(), AID.empty() ? "N/A" : AID.c_str(), exponent, bitLo, wantsPm1);
     return buf;
   }
 };


### PR DESCRIPTION
Same as #246, but for your v6 branch. This is needed for @Danc2050 and I's PrimeNet script, which also supports GpuOwl v6.11 because it is allegedly faster for some users and still supports LL DC and standalone P-1. I got a request explicitly for this from user [techn1ciaN](https://www.mersenneforum.org/member.php?u=16918) on the Mersenne Forum.

* Added support for the `PRPDC=` prefix for PRP DC assignments, for consistency with Prime95/MPrime and Mlucas.
* Improved parsing of the assignment ID by separating the `N/A` case.
* Added support for PRP assignments without an assignment ID, for consistency with Prime95/MPrime and Mlucas.
* Added support for doing P-1 before LL DC assignments.
* Enabled `-O3` optimization in the Makefile.
* Copied the Continuous Integration (CI) from the master branch (#217) so these and any future changes would be tested.

See #246 and #217 for the full details. Note that this does build with Clang on Linux, as it precedes the regressing commit https://github.com/preda/gpuowl/commit/817a9831dc9fdc595709bd5f68482e654b758b65.