### PR TITLE
Updated Continuous Integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,32 +11,26 @@ jobs:
     name: Linux
 
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ (matrix.os == 'ubuntu-18.04' && matrix.cxx == 'g++') || matrix.cxx == 'clang++' }}
+    continue-on-error: ${{ matrix.cxx == 'clang++' }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         cxx: [g++, clang++]
       fail-fast: false
     env:
       CXX: ${{ matrix.cxx }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install
       run: |
         sudo apt-get -yqq update
         sudo apt-get -yqq install cppcheck ocl-icd-opencl-dev
         $CXX --version
-    - name: Before script
-      if: ${{ matrix.os == 'ubuntu-18.04' && matrix.cxx == 'g++' }}
-      run: |
-        sed -i 's/<filesystem>/<experimental\/filesystem>/' *.h *.cpp
-        sed -i 's/std::filesystem/std::experimental::filesystem/' *.h *.cpp
-        sed -i 's/assert(false);/abort();/' Pm1Plan.cpp
     - name: Script
       run: |
         make -j "$(nproc)"
         ./gpuowl -h
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: always()
       with:
         name: ${{ matrix.os }}_${{ matrix.cxx }}_gpuowl
@@ -58,13 +52,12 @@ jobs:
     env:
       CXX: ${{ matrix.cxx }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Script
       run: |
-        echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         make gpuowl-win.exe
         .\gpuowl-win.exe -h
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: always()
       with:
         name: win_${{ matrix.cxx }}_gpuowl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
     env:
       CXX: ${{ matrix.cxx }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install
       run: |
         sudo apt-get -yqq update
-        sudo apt-get -yqq install cppcheck ocl-icd-* opencl-headers
+        sudo apt-get -yqq install cppcheck ocl-icd-opencl-dev
         $CXX --version
-    - name: Before
+    - name: Before script
       if: ${{ matrix.os == 'ubuntu-18.04' && matrix.cxx == 'g++' }}
       run: |
         sed -i 's/<filesystem>/<experimental\/filesystem>/' *.h *.cpp
@@ -36,8 +36,13 @@ jobs:
       run: |
         make -j "$(nproc)"
         ./gpuowl -h
+    - uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: ${{ matrix.os }}_${{ matrix.cxx }}_gpuowl
+        path: ${{ github.workspace }}
     - name: Cppcheck
-      run: cppcheck --enable=all .
+      run: cppcheck --enable=all --force .
     - name: ShellCheck
       run: bash -c 'shopt -s globstar; shellcheck -s bash **/*.sh || true'
 
@@ -47,8 +52,13 @@ jobs:
     runs-on: windows-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Script
       run: |
         make gpuowl-win.exe
-        ./gpuowl-win.exe -h
+        .\gpuowl-win.exe -h
+    - uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: gpuowl-win
+        path: ${{ github.workspace }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,21 @@ jobs:
 
     runs-on: windows-latest
     continue-on-error: true
+    strategy:
+      matrix:
+        cxx: [g++, clang++]
+      fail-fast: false
+    env:
+      CXX: ${{ matrix.cxx }}
     steps:
     - uses: actions/checkout@v2
     - name: Script
       run: |
+        echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         make gpuowl-win.exe
         .\gpuowl-win.exe -h
     - uses: actions/upload-artifact@v2
       if: always()
       with:
-        name: gpuowl-win
+        name: win_${{ matrix.cxx }}_gpuowl
         path: ${{ github.workspace }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,10 @@ matrix:
 
 install:
   - sudo apt-get -yqq update
-  - sudo apt-get -yqq install cppcheck ocl-icd-* opencl-headers
+  - sudo apt-get -yqq install cppcheck ocl-icd-opencl-dev
 script:
   - make -j "$(nproc)"
   - ./gpuowl -h
-  - cppcheck --enable=all .
+  - cppcheck --enable=all --force .
   - bash -c 'shopt -s globstar; shellcheck -s bash **/*.sh || true'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,6 @@ language: cpp
 
 matrix:
   include:
-  - name: "Ubuntu 18.04 (gcc)"
-    os: linux
-    dist: bionic
-    compiler: gcc
-    virt: vm
-    before_script:
-      - sed -i 's/<filesystem>/<experimental\/filesystem>/' *.h *.cpp
-      - sed -i 's/std::filesystem/std::experimental::filesystem/' *.h *.cpp
-      - sed -i 's/assert(false);/abort();/' Pm1Plan.cpp
-  - name: "Ubuntu 18.04 (clang)"
-    os: linux
-    dist: bionic
-    compiler: clang
-    virt: vm
-    before_script:
-      - sed -i 's/<filesystem>/<experimental\/filesystem>/' *.h *.cpp
-      - sed -i 's/std::filesystem/std::experimental::filesystem/' *.h *.cpp
   - name: "Ubuntu 20.04 (gcc)"
     os: linux
     dist: focal

--- a/Args.cpp
+++ b/Args.cpp
@@ -61,16 +61,16 @@ void Args::printHelp() {
 -rB2               : ratio of B2 to B1. Default %u, used only if B2 is not explicitly set
 -prp <exponent>    : run a single PRP test and exit, ignoring worktodo.txt
 -verify <file>     : verify PRP-proof contained in <file>
--proof <power>     : By default a proof of power 8 is generated, using 3GB of temporary disk space for a 100M exponent.
+-proof <power>     : By default a proof of power %u is generated, using 3GB of temporary disk space for a 100M exponent.
                      A lower power reduces disk space requirements but increases the verification cost.
                      A proof of power 9 uses 6GB of disk space for a 100M exponent and enables faster verification.
--autoverify <power> : Self-verify proofs generated with at least this power. Default 9.
--tmpDir <dir>      : specify a folder with plenty of disk space where temporary proof checkpoints will be stored.
--results <file>    : name of results file, default 'results.txt'
+-autoverify <power> : Self-verify proofs generated with at least this power. Default %u.
+-tmpDir <dir>      : specify a folder with plenty of disk space where temporary proof checkpoints will be stored, default '%s'.
+-results <file>    : name of results file, default '%s'
 -iters <N>         : run next PRP test for <N> iterations and exit. Multiple of 10000.
 -maxAlloc <size>   : limit GPU memory usage to size, which is a value with suffix M for MB and G for GB.
                      e.g. -maxAlloc 2048M or -maxAlloc 3.5G
--save <N>          : specify the number of savefiles to keep (default 12).
+-save <N>          : specify the number of savefiles to keep (default %u).
 -noclean           : do not delete data after the test is complete.
 -from <iteration>  : start at the given iteration instead of the most recent saved iteration
 -yield             : enable work-around for Nvidia GPUs busy wait. Do not use on AMD GPUs!
@@ -79,7 +79,7 @@ void Args::printHelp() {
 -unsafeMath        : use OpenCL -cl-unsafe-math-optimizations (use at your own risk)
 -binary <file>     : specify a file containing the compiled kernels binary
 -device <N>        : select a specific device:
-)", B2_B1_ratio);
+)", B2_B1_ratio, proofPow, proofVerify, tmpDir.c_str(), resultsFile.c_str(), nSavefiles);
 
   // Undocumented:
   // -D <value>         : specify the P2 "D" value, one of: 210, 330, 420, 462, 660, 770, 924, 1540, 2310.

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ version.inc: FORCE
 	echo Version: `cat version.inc`
 
 gpuowl-expanded.cl: gpuowl.cl
-	./tools/expand.py < gpuowl.cl > gpuowl-expanded.cl
+	python3 tools/expand.py < gpuowl.cl > gpuowl-expanded.cl
 
 gpuowl-wrap.cpp: gpuowl-expanded.cl head.txt tail.txt
 	cat head.txt gpuowl-expanded.cl tail.txt > gpuowl-wrap.cpp

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ In practice, PRP is preferred over LL because PRP does have a very strong and us
 
 ## GpuOwl: OpenCL GPU Mersenne primality testing
 GpuOwl implements the PRP and P-1 tests. It also implemented, at various points in the past, LL and TF but these are not active now
-in GpuOwl. For double check (DC) LL tests, see [version 6.11](https://github.com/preda/gpuowl/releases/tag/v6.11) and for first time LL tests, see the [LL branch](https://github.com/preda/gpuowl/tree/LL) (version 0.6).
+in GpuOwl. For double check (DC) LL tests, see the [v6 branch](https://github.com/preda/gpuowl/tree/v6) (version 6.11-380) and for first time LL tests, see the [LL branch](https://github.com/preda/gpuowl/tree/LL) (version 0.6).
 
 Let us consider the PRP test, to get an idea of what GpuOwl does under the hood.
 
@@ -94,15 +94,15 @@ The first form indicates just the exponent to test, while the form starting with
 exponent and optionally the assignment ID (AID) from PrimeNet. The `PRPDC=` prefix can be used instead for PRP DC assignments.
 
 ## Usage
-* Get "PRP smallest available first time tests" assignments from GIMPS Manual Testing ( http://mersenne.org/ ).
+* Get "PRP smallest available first time tests" assignments from GIMPS Manual Testing ( https://www.mersenne.org/manual_assignment/ ).
 * Copy the assignment lines from GIMPS to a file named '`worktodo.txt`'
 * Run `gpuowl`. It prints progress report on stdout and in `gpuowl.log`, and writes result lines to `results.txt`
-* Submit the result lines from `results.txt` to http://mersenne.org/ manual testing.
+* Submit the result lines from `results.txt` to https://www.mersenne.org/manual_result/ manual testing.
 
 ## Build
 To build simply invoke "`make`" (or look inside the Makefile for a manual build).
 
-* the GNU Multiple Precision (GMP) library `libgmp-dev`
+* the GNU Multiple Precision (GMP) 6.1 library `libgmp-dev`
 * a C++20 compiler (e.g. GCC, Clang)
 * an OpenCL implementation (which provides the **libOpenCL** library). Recommended: an AMD GPU with ROCm 1.7.
 

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ The probable prime test can prove that a candidate is composite (without providi
 is prime (only stating that it _probably_ is prime) -- although in practice the difference between probable prime and proved
 prime is extremely small for large Mersenne candidates.
 
-The PRP test is very similar computationally to LL: PRP iterates f(x) = x^2 modulo M(p) starting from 3, for p iterations. The cost
+The PRP test is very similar computationally to LL: PRP iterates f(x) = x^2 modulo M(p) starting from 3. If after p iterations the result is 9 modulo M(p), then M(p) is probably prime, otherwise M(p) is certainly not prime. The cost
 of PRP is exactly the same as LL.
 
 In practice, PRP is preferred over LL because PRP does have a very strong and useful error-checking technique, which protects effectively against computation errors (which are sometimes common on GPUs).
 
 ## GpuOwl: OpenCL GPU Mersenne primality testing
 GpuOwl implements the PRP and P-1 tests. It also implemented, at various points in the past, LL and TF but these are not active now
-in GpuOwl. For double check (DC) LL tests, see the [v6 branch](https://github.com/preda/gpuowl/tree/v6) (version 6.11-380) and for first time LL tests, see the [LL branch](https://github.com/preda/gpuowl/tree/LL) (version 0.6).
+in GpuOwl. For double check (DC) LL tests, see the [v6 branch](https://github.com/preda/gpuowl/tree/v6) (version 6.11-382) and for first time LL tests, see the [LL branch](https://github.com/preda/gpuowl/tree/LL) (version 0.6).
 
 Let us consider the PRP test, to get an idea of what GpuOwl does under the hood.
 
@@ -127,7 +127,7 @@ Simply start GpuOwl with any valid exponent, and the built-in error checking kic
 -carry long|short  : force carry type. Short carry may be faster, but requires high bits/word.
 -B1                : P-1 B1 bound
 -B2                : P-1 B2 bound
--rB2               : ratio of B2 to B1. Default 30, used only if B2 is not explicitly set
+-rB2               : ratio of B2 to B1. Default 20, used only if B2 is not explicitly set
 -prp <exponent>    : run a single PRP test and exit, ignoring worktodo.txt
 -verify <file>     : verify PRP-proof contained in <file>
 -proof <power>     : By default a proof of power 8 is generated, using 3GB of temporary disk space for a 100M exponent.


### PR DESCRIPTION
* Updated the Continuous Integration (CI) from #217.
  * Changed GitHub Actions to also build with Ubuntu 22.04.
  * Removed Ubuntu 18.04, which never worked.
  * Changed GitHub Actions to also build with Clang on Windows.
  * Set Cppcheck to check all `#ifdef` configurations.
  * Configured GitHub Actions so users can download the resulting GpuOwl binaries.
    * This is mainly for Windows and other users who are unable to directly build GpuOwl. They can be downloaded from the "Actions" tab above.
* Updated help output to get default values from the respective variables.
* Updated the README.
  * Updated command line options section to reflect the current `gpuowl -h` output.
  * Minor copy edits.

Note that https://github.com/preda/gpuowl/commit/817a9831dc9fdc595709bd5f68482e654b758b65 broke Clang support, so the CI currently allows those builds to fail. I would be happy to remove these builds and update the README if Clang is no longer supported.