### PR TITLE
Update Gpu.cpp

### DIFF
--- a/Gpu.cpp
+++ b/Gpu.cpp
@@ -25,6 +25,7 @@
 #include <bitset>
 #include <limits>
 #include <iomanip>
+#include <array>
 
 #ifndef M_PIl
 #define M_PIl 3.141592653589793238462643383279502884L


### PR DESCRIPTION
Msys2 (MinGW-w64) fix for build error : 
Gpu.cpp:1147:126: error: 'exponents' has incomplete type
 1147 |   SquaringSet(Gpu& gpu, u32 N, const Buffer<double>& bufBase, Buffer<double>& bufTmp, Buffer<double>& bufTmp2, array<u64, 3> exponents, string_view name)