### PR TITLE
Update clwrap.cpp

### DIFF
--- a/clwrap.cpp
+++ b/clwrap.cpp
@@ -11,6 +11,7 @@
 #include <new>
 #include <memory>
 #include <vector>
+#include <array>
 
 using namespace std;
 


### PR DESCRIPTION
Msys2 (MinGW-w64) fix for build error:
g++ -MT clwrap.o -MMD -MP -MF .d/clwrap.Td -Wall -g -O3 -std=gnu++17   -c -o clwrap.o clwrap.cpp
clwrap.cpp:19:19: error: variable 'std::array<std::__cxx11::basic_string<char>, 71> ERR_MES' has initializer but incomplete type
   19 | array<string, 71> ERR_MES = {
      |                   ^~~~~~~
make: *** [Makefile:33: clwrap.o] Error 1