### PR TITLE
Update Sha3Hash.h

### DIFF
--- a/Sha3Hash.h
+++ b/Sha3Hash.h
@@ -4,6 +4,8 @@
 
 #include "sha3.h"
 
+#include <array>
+
 class Sha3Hash {
   SHA3Context context;
   static const constexpr int SIZE_BITS = 256;


### PR DESCRIPTION
Fix for xcom169's issue (https://github.com/preda/gpuowl/issues/254) & Msys2 (MinGW-w64) build error for win64 :

In file included from Proof.cpp:5:
Sha3Hash.h:18:29: error: return type ‘struct std::array<long unsigned int, 4>’ is incomplete 18 | array<u64, 4> finish() && {
| ^
Proof.cpp: In function ‘std::array<long unsigned int, 4> proof::hashWords(u32, const Words&)’: Proof.cpp:24:66: error: could not convert ‘(& std::move<Hash&>((* & Hash().Hash::update(((const void*)(& words)->std::vector::data()), (((E - 1) / 8) + 1)))))->Hash::finish()’ from ‘void’ to ‘std::array<long unsigned int, 4>’ 24 | return std::move(SHA3{}.update(words.data(), (E-1)/8+1)).finish(); | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~ | |
| void
Proof.cpp: In function ‘std::array<long unsigned int, 4> proof::hashWords(u32, std::array<long unsigned int, 4>, const Words&)’: Proof.cpp:28:81: error: could not convert ‘(& std::move<Hash&>((* &(& Hash().Hash::update<long unsigned int, 4>(prefix))->Hash::update(((const void*)(& words)->std::vector::data()), (((E - 1) / 8) + 1)))))->Hash::finish()’ from ‘void’ to ‘std::array<long unsigned int, 4>’ 28 | return std::move(SHA3{}.update(prefix).update(words.data(), (E-1)/8+1)).finish(); | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~ | |
| void
make: *** [Makefile:33: Proof.o] Error 1