### PR TITLE
Use barrier(CLK_LOCAL_MEM_FENCE) instead of barrier(0)

### DIFF
--- a/src/gpuowl.cl
+++ b/src/gpuowl.cl
@@ -217,7 +217,7 @@ void bar() {
 #if 0 && HAS_ASM
    __asm("s_barrier");
 #else
-   barrier(0);
+   barrier(CLK_LOCAL_MEM_FENCE);
 #endif
 }
 


### PR DESCRIPTION
Hello,

We found a problem when using gpuowl when testing a ROCm release.

It seems to me that `barrier(0)` is being used to synchronaize the work-items in a workgroup after they write to shared memory.

But when the argument is set to 0, it is not ensured that the changes done to shared memory are visible by all work-items in the workgroup.

Instead, we propose using [CLK_LOCAL_MEM_FENCE](https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/barrier.html):

> CLK_LOCAL_MEM_FENCE - ensure that all local memory accesses become visible to all work-items in the work-group. Note that the value of scope is ignored as the memory scope is always memory_scope_work_group.

Don't hesitate to raise any issues in the patch I'm proposing, I started using OpenCL quite recently.

Best!
