### PR TITLE
Fix cmake build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_executable(gpuowl
+add_executable(prpll
   Primes.cpp
   bundle.cpp
   Proof.cpp
@@ -19,6 +19,27 @@ add_executable(gpuowl
   tune.cpp
   TuneEntry.cpp
   fs.cpp
+  version.inc
   )
 
-target_link_libraries(gpuowl OpenCL)
+target_link_libraries(prpll OpenCL)
+
+target_include_directories(prpll PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_command(
+  OUTPUT version.inc
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  COMMAND git describe --tags --long --dirty --always --match ${CMAKE_SOURCE_DIR} | sed 's/.*/"&"/' > ${CMAKE_CURRENT_BINARY_DIR}/version.inc
+  DEPENDS ${CMAKE_SOURCE_DIR}
+  )
+
+file(
+  GLOB CL_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/cl/*.cl
+  )
+
+add_custom_command(
+  OUTPUT bundle.cpp
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  COMMAND ${CMAKE_SOURCE_DIR}/genbundle.sh ${CL_SOURCES} > ${CMAKE_CURRENT_BINARY_DIR}/bundle.cpp
+  DEPENDS ${CL_SOURCES}
+  )


### PR DESCRIPTION
I don't know if there is any interest in supporting cmake. I would prefer to have a single build system, and I would prefer to use cmake over having a plain `Makefile` (it's also possible to have a simple top-level `Makefile` that would call cmake). This PR fixes the obvious breakage. More improvements might be needed if cmake is chosen as the only way to build prpll.