### PR TITLE
Add support for MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,24 @@ jobs:
       with:
         name: win_${{ matrix.cxx }}_prpll
         path: ${{ github.workspace }}
+
+  macOS:
+    name: macOS
+
+    runs-on: macos-13
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install
+      run: |
+        brew install gcc@14
+    - name: Script
+      run: |
+        make prpll -j "$(sysctl -n hw.ncpu)"
+        cd build-release
+        rm -f -- *.o
+        ./prpll -h
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: macos_prpll
+        path: ${{ github.workspace }}

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,24 @@
 # or export those into environment, or pass on the command line e.g.
 # make all DEBUG=1 CXX=g++-12
 
+HOST_OS = $(shell uname -s)
+
+ifeq ($(HOST_OS), Darwin)
+# Real GCC (not clang), needed for 128-bit floats and std::filesystem::path
+CXX = g++-14
+else
+CXX = g++
+endif
+
 COMMON_FLAGS = -Wall -std=c++20
 # -static-libstdc++ -static-libgcc
 # -fext-numeric-literals
+
+ifeq ($(HOST_OS), Darwin)
+OPENCL_LIBS = -framework OpenCL
+else
+OPENCL_LIBS = -lOpenCL
+endif
 
 
 ifeq ($(DEBUG), 1)
@@ -54,7 +69,7 @@ amd: $(BIN)/prpll-amd
 #	$(CXX) $(CXXFLAGS) -o $@ $< $(LIBPATH) ${STRIP}
 
 $(BIN)/prpll: ${OBJS}
-	$(CXX) $(CXXFLAGS) -o $@ ${OBJS} $(LIBPATH) -lOpenCL ${STRIP}
+	$(CXX) $(CXXFLAGS) -o $@ ${OBJS} $(LIBPATH) $(OPENCL_LIBS) ${STRIP}
 
 # Instead of linking with libOpenCL, link with libamdocl64
 $(BIN)/prpll-amd: ${OBJS}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,20 @@ add_executable(prpll
   version.inc
   )
 
-target_link_libraries(prpll OpenCL)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  # Real GCC (not clang), needed for 128-bit floats and std::filesystem::path
+  set(CMAKE_CXX_COMPILER g++-14)
+endif()
+
+find_package(OpenCL)
+
+if (${OpenCL_FOUND})
+  # Use OpenCL library found by cmake
+  target_link_libraries(prpll OpenCL::OpenCL)
+else()
+  # Pass -lOpenCL to the linker and hope for the best
+  target_link_libraries(prpll OpenCL)
+endif()
 
 target_include_directories(prpll PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/src/File.h
+++ b/src/File.h
@@ -18,6 +18,10 @@
 #include <io.h>
 #endif
 
+#if defined(__APPLE__)
+#include <fcntl.h>
+#endif
+
 #if defined(_DEFAULT_SOURCE) || defined(_BSD_SOURCE)
 #define HAS_SETLINEBUF 1
 #else
@@ -54,6 +58,8 @@ class File {
     fflush(f);
 #if defined(_WIN32) || defined(__WIN32__)
     _commit(fileno(f));
+#elif defined(__APPLE__)
+    fcntl(fileno(f), F_FULLFSYNC, 0);
 #else
     fdatasync(fileno(f));
 #endif

--- a/src/cl/base.cl
+++ b/src/cl/base.cl
@@ -138,12 +138,17 @@ typedef global const double2* BigTab;
 
 #define KERNEL(x) kernel __attribute__((reqd_work_group_size(x, 1, 1))) void
 
+// Prototypes
+void read(u32 WG, u32 N, T2 *u, const global T2 *in, u32 base);
+void write(u32 WG, u32 N, T2 *u, global T2 *out, u32 base);
+void bar(void);
+
 void read(u32 WG, u32 N, T2 *u, const global T2 *in, u32 base) {
-  for (i32 i = 0; i < N; ++i) { u[i] = in[base + i * WG + (u32) get_local_id(0)]; }
+  for (u32 i = 0; i < N; ++i) { u[i] = in[base + i * WG + (u32) get_local_id(0)]; }
 }
 
 void write(u32 WG, u32 N, T2 *u, global T2 *out, u32 base) {
-  for (i32 i = 0; i < N; ++i) { out[base + i * WG + (u32) get_local_id(0)] = u[i]; }
+  for (u32 i = 0; i < N; ++i) { out[base + i * WG + (u32) get_local_id(0)] = u[i]; }
 }
 
 void bar() {

--- a/src/cl/transpose.cl
+++ b/src/cl/transpose.cl
@@ -2,7 +2,10 @@
 
 #include "base.cl"
 
-void transposeWords(u32 W, u32 H, local Word2 *lds, const Word2 *in, Word2 *out) {
+// Prototypes
+void transposeWords(u32 W, u32 H, local Word2 *lds, global const Word2 *restrict in, global Word2 *restrict out);
+
+void transposeWords(u32 W, u32 H, local Word2 *lds, global const Word2 *restrict in, global Word2 *restrict out) {
   u32 GPW = W / 64, GPH = H / 64;
 
   u32 g = get_group_id(0);

--- a/src/clwrap.cpp
+++ b/src/clwrap.cpp
@@ -292,7 +292,11 @@ cl_queue makeQueue(cl_device_id d, cl_context c, bool isProfile) {
   props[1] = isProfile ? CL_QUEUE_PROFILING_ENABLE : 0;
   // CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE not supported on ROCm 6.1 or earlier
 
+#ifdef __APPLE__
+  cl_queue q = clCreateCommandQueueWithPropertiesAPPLE(c, d, props, &err);
+#else
   cl_queue q = clCreateCommandQueueWithProperties(c, d, props, &err);
+#endif
   CHECK2(err, "clCreateCommandQueue");
   return q;
 }

--- a/src/tinycl.h
+++ b/src/tinycl.h
@@ -66,7 +66,11 @@ cl_kernel clCreateKernel(cl_program, const char *, int *);
 int clReleaseKernel(cl_kernel);
 cl_mem clCreateBuffer(cl_context, cl_mem_flags, size_t, void *, int *);
 int clReleaseMemObject(cl_mem);
+#ifdef __APPLE__
+cl_command_queue clCreateCommandQueueWithPropertiesAPPLE(cl_context, cl_device_id, const cl_queue_properties *, int *);
+#else
 cl_command_queue clCreateCommandQueueWithProperties(cl_context, cl_device_id, const cl_queue_properties *, int *);
+#endif
   
 int clEnqueueReadBuffer(cl_command_queue, cl_mem, cl_bool, size_t, size_t, void *,
                         unsigned numEvents, const cl_event *waitEvents, cl_event *outEvent);


### PR DESCRIPTION
This is for x86_64 only. No attempt was made to support Apple Silicon. However, this PR could be used as a spepping stone in that direction.

The remaining problem is an error when running `prpll`:

```
Exception gpu_error: INVALID_WORK_GROUP_SIZE (-54) transpIn at /Users/plroskin/src/gpuowl/src/clwrap.cpp:312 run
```

That would need to be addressed by an OpenCL expert. It's possible that the issue is specific to my hardware or software.

However, many other issues have been addressed is a clean way.

* The real gcc (e.g. from homebrew) is selected for the build (clang doesn't support 128-bit floating point and `std::filesystem::path` in the standard library).
* OpenCL is linked the way is should be on MacOS with the `-framework OpenCL` linker directive.
* The cmake build uses cmake facilities to search for OpenCL and link to it.
* A replacement for `fdatasync()` is used on MacOS.
* OpenCL functions have prototypes when needed.
* Comparison between `i32` and `u32` in OpenCL code has been fixed.
* `transposeWords` uses signature that preserves `global` and `restrict` attributes used by the callers.
* `clCreateCommandQueueWithProperties` is missing on MacOS, use `clCreateCommandQueueWithPropertiesAPPLE` instead.

Basically, the C++ code compiles, the OpenCL code compiles and loads, but fails to run on the GPU.