### PR TITLE
More stride elimination work for AMD GPUs

### DIFF
--- a/src/Gpu.cpp
+++ b/src/Gpu.cpp
@@ -252,11 +252,13 @@ string clDefines(const Args& args, cl_device_id id, FFTConfig fft, const vector<
   defines += toDefine("TRIG_SIN",  coefs.sinCoefs);
   defines += toDefine("TRIG_COS",  coefs.cosCoefs);
 
+  // Calculate fractional bits-per-word = (E % N) / N * 2^64
   u32 bpw_hi = (u64(E % N) << 32) / N;
   u32 bpw_lo = (((u64(E % N) << 32) % N) << 32) / N;
-  defines += toDefine("FRAC_BPW_HI", bpw_hi);
-  defines += toDefine("FRAC_BPW_LO", bpw_lo);
   u64 bpw = (u64(bpw_hi) << 32) + bpw_lo;
+  bpw--; // bpw must not be an exact value -- it must be less than exact value to get last biglit value right
+  defines += toDefine("FRAC_BPW_HI", (u32) (bpw >> 32));
+  defines += toDefine("FRAC_BPW_LO", (u32) bpw);
   u32 bigstep = (bpw * (N / fft.shape.nW())) >> 32;
   defines += toDefine("FRAC_BITS_BIGSTEP", bigstep);
 

--- a/src/Gpu.cpp
+++ b/src/Gpu.cpp
@@ -458,9 +458,9 @@ Gpu::Gpu(Queue* q, GpuCommon shared, FFTConfig fft, u32 E, const vector<KeyVal>&
   BUF(bufROE, ROE_SIZE),
   BUF(bufStatsCarry, CARRY_SIZE),
 
-  BUF(buf1, N),
-  BUF(buf2, N),
-  BUF(buf3, N),
+  BUF(buf1, N + N/4),		// Let's us play with padding instead of rotating.  Need to calculate actual cost of padding
+  BUF(buf2, N + N/4),
+  BUF(buf3, N + N/4),
 #undef BUF
 
   statsBits{u32(args.value("STATS", 0))},

--- a/src/cl/base.cl
+++ b/src/cl/base.cl
@@ -151,116 +151,14 @@ void write(u32 WG, u32 N, T2 *u, global T2 *out, u32 base);
 void bar(void);
 
 void read(u32 WG, u32 N, T2 *u, const global T2 *in, u32 base) {
-  for (u32 i = 0; i < N; ++i) { u[i] = in[base + i * WG + (u32) get_local_id(0)]; }
+  in += base + (u32) get_local_id(0);
+  for (u32 i = 0; i < N; ++i) { u[i] = in[i * WG]; }
 }
 
 void write(u32 WG, u32 N, T2 *u, global T2 *out, u32 base) {
   out += base + (u32) get_local_id(0);
   for (u32 i = 0; i < N; ++i) { out[i * WG] = u[i]; }
 }
-
-// Parameters we may want to let user tune.  WIDTH other than 512 and 1K is untested.  SMALL_HEIGHT other than 256 and 512 is untested.
-#define ROTATION 1                              // Turns on rotating width and small_height rows
-#define WIDTH_ROTATE_CHUNK_SIZE 32              // Rotate blocks of 32 T2 values = 512 bytes
-#define HEIGHT_ROTATE_CHUNK_SIZE 16             // Rotate blocks of 16 T2 values = 256 bytes
-#define VARIABLE_WIDTH_ROTATE 0                 // Each width u[i] gets a different rotation amount
-#define MIDDLE_SHUFFLE_WRITE 1                  // Radeon VII likes MiddleShuffleWrite, Titan V apparently not
-
-// nVidia Titan V hates rotating and LDS-less middle writes
-#if !AMDGPU
-#undef ROTATION
-#define ROTATION 0
-#undef MIDDLE_SHUFFLE_WRITE
-#define MIDDLE_SHUFFLE_WRITE 0
-#endif
-
-// Rotate width elements on output from fft_WIDTH and as input to fftMiddleIn.
-// Not all lines are rotated the same amount so that fftMiddleIn reads a more varied distribution of addresses.
-// This can be faster on AMD GPUs, not certain about nVidia GPUs.
-u32 rotate_width_amount(u32 y) {
-#if !VARIABLE_WIDTH_ROTATE
-  u32 num_sections = WIDTH / WIDTH_ROTATE_CHUNK_SIZE;
-  u32 num_rotates = y % num_sections;           // if y increments by SMALL_HEIGHT, final rotate amount won't change after applying "mod WIDTH"
-#else
-  // Create a formula where each u[i] gets a different rotation amount
-  u32 num_sections = WIDTH / WIDTH_ROTATE_CHUNK_SIZE;
-  u32 num_rotates = y % num_sections * MIDDLE;  // each increment of y adds MIDDLE
-  num_rotates += y / SMALL_HEIGHT;              // each increment of i in u[i] will add 1
-  num_rotates &= 255;                           // keep num_rotates small (probably not necessary)
-#endif
-  return num_rotates * WIDTH_ROTATE_CHUNK_SIZE;
-}
-u32 rotate_width_x(u32 x, u32 rot_amt) {        // rotate x coordinate using a cached rotate_amount
-  return (x + rot_amt) % WIDTH;
-}
-u32 rotate_width(u32 y, u32 x) {                // rotate x coordinate (no cached rotate amount)
-  return rotate_width_x(x, rotate_width_amount(y));
-}
-void readRotatedWidth(T2 *u, CP(T2) in, u32 y, u32 x) {
-#if !ROTATION                                   // No rotation, might be better on nVidia cards
-  in += y * WIDTH + x;
-  for (i32 i = 0; i < MIDDLE; ++i) { u[i] = in[i * SMALL_HEIGHT * WIDTH]; }
-#elif !VARIABLE_WIDTH_ROTATE                    // True if adding SMALL_HEIGHT to y results in same rotation amount
-  in += y * WIDTH + rotate_width(y, x);
-  for (i32 i = 0; i < MIDDLE; ++i) { u[i] = in[i * SMALL_HEIGHT * WIDTH]; }
-#else                                           // Adding SMALL_HEIGHT to y results in different rotation
-  in += y * WIDTH;
-  u32 rot_amt = rotate_width_amount(y);
-  for (i32 i = 0; i < MIDDLE; ++i) { u[i] = in[rotate_width_x(x, rot_amt)]; in += SMALL_HEIGHT * WIDTH; rot_amt += SMALL_HEIGHT * WIDTH_ROTATE_CHUNK_SIZE; }
-#endif
-}
-void writeRotatedWidth(u32 WG, u32 N, T2 *u, P(T2) out, u32 line) {
-#if !ROTATION                                   // No rotation, might be better on nVidia cards
-  out += line * WIDTH + (u32) get_local_id(0);
-  for (u32 i = 0; i < N; ++i) { out[i * WG] = u[i]; }
-#else
-  u32 me = (u32) get_local_id(0);
-  u32 rot_amt = rotate_width_amount(line);
-  out += line * WIDTH;
-  for (u32 i = 0; i < N; ++i) { out[rotate_width_x (i * WG + me, rot_amt)] = u[i]; }
-#endif
-}
-
-// Rotate height elements on output from fft_HEIGHT and as input to fftMiddleOut.
-// Not all lines are rotated the same amount so that fftMiddleOut reads a more varied distribution of addresses.
-// This can be faster on AMD GPUs, not certain about nVidia GPUs.
-u32 rotate_height_amount (u32 y) {
-  u32 num_sections = SMALL_HEIGHT / HEIGHT_ROTATE_CHUNK_SIZE;
-  return (y % num_sections) * (HEIGHT_ROTATE_CHUNK_SIZE);
-}
-u32 rotate_height_x(u32 x, u32 rot_amt) {       // rotate x coordinate using a cached rotate_amount
-  return (x + rot_amt) % SMALL_HEIGHT;
-}
-u32 rotate_height(u32 y, u32 x) {               // rotate x coordinate (no cached rotate amount)
-  return rotate_height_x(x, rotate_height_amount(y));
-}
-void readRotatedHeight(T2 *u, CP(T2) in, u32 y, u32 x) {
-#if !ROTATION                                   // No rotation, might be better on nVidia cards
-  in += y * MIDDLE * SMALL_HEIGHT + x;
-  for (i32 i = 0; i < MIDDLE; ++i) { u[i] = in[i * SMALL_HEIGHT]; }
-#elif 0                                         // Set if adding 1 to y results in same rotation
-  y *= MIDDLE;
-  in += y * SMALL_HEIGHT + rotate_height(y, x);
-  for (i32 i = 0; i < MIDDLE; ++i) { u[i] = in[i * SMALL_HEIGHT]; }
-#else                                           // Adding SMALL_HEIGHT to line results in different rotation
-  y *= MIDDLE;
-  in += y * SMALL_HEIGHT;
-  u32 rot_amt = rotate_height_amount(y);
-  for (i32 i = 0; i < MIDDLE; ++i) { u[i] = in[rotate_height_x(x, rot_amt)]; in += SMALL_HEIGHT; rot_amt += HEIGHT_ROTATE_CHUNK_SIZE; }
-#endif
-}
-void writeRotatedHeight(u32 WG, u32 N, T2 *u, P(T2) out, u32 line) {
-#if !ROTATION                                   // No rotation, might be better on nVidia cards
-  out += line * SMALL_HEIGHT + (u32) get_local_id(0);
-  for (u32 i = 0; i < N; ++i) { out[i * WG] = u[i]; }
-#else
-  u32 me = (u32) get_local_id(0);
-  u32 rot_amt = rotate_height_amount(line);
-  out += line * SMALL_HEIGHT;
-  for (u32 i = 0; i < N; ++i) { out[rotate_height_x (i * WG + me, rot_amt)] = u[i]; }
-#endif
-}
-
 
 T2 U2(T a, T b) { return (T2) (a, b); }
 

--- a/src/cl/carryfused.cl
+++ b/src/cl/carryfused.cl
@@ -62,7 +62,10 @@ KERNEL(G_W) carryFused(P(T2) out, CP(T2) in, u32 posROE, P(i64) carryShuttle, P(
   // On Titan V it is faster to derive the big vs. little flags from the fractional number of bits in each FFT word rather read the flags from memory.
   // On Radeon VII this code is about he same speed.  Not sure which is better on other GPUs.
 #if BIGLIT
-  u32 frac_bits = (u32) (((me * H + line) * 2 * ((((u64) FRAC_BPW_HI) << 32) + FRAC_BPW_LO)) >> 32);
+  // Calculate the most significant 32-bits of FRAC_BPW * the index of the FFT word
+  u32 fft_word_index = (me * H + line) * 2;
+  u32 frac_bits = fft_word_index * FRAC_BPW_HI + (u32) ((fft_word_index * (u64) FRAC_BPW_LO) >> 32);
+  // Perform addition to test first biglit flag
   u32 tmp = frac_bits + FRAC_BPW_HI;
 #endif
 

--- a/src/cl/carryfused.cl
+++ b/src/cl/carryfused.cl
@@ -170,7 +170,7 @@ KERNEL(G_W) carryFused(P(T2) out, CP(T2) in, u32 posROE, P(i64) carryShuttle, P(
   bar();
 
   fft_WIDTH(lds, u, smallTrig);
-  writeRotatedWidth(G_W, NW, u, out, line);
+  writeCarryFusedLine(u, out, line);
 
   // Clear carry ready flag for next iteration
 #if OLD_FENCE

--- a/src/cl/fftp.cl
+++ b/src/cl/fftp.cl
@@ -4,6 +4,7 @@
 #include "math.cl"
 #include "weight.cl"
 #include "fftwidth.cl"
+#include "middle.cl"
 
 // fftPremul: weight words with IBDWT weights followed by FFT-width.
 KERNEL(G_W) fftP(P(T2) out, CP(Word2) in, Trig smallTrig, BigTab THREAD_WEIGHTS) {
@@ -28,5 +29,5 @@ KERNEL(G_W) fftP(P(T2) out, CP(Word2) in, Trig smallTrig, BigTab THREAD_WEIGHTS)
 
   fft_WIDTH(lds, u, smallTrig);
  
-  writeRotatedWidth(G_W, NW, u, out, g);
+  writeCarryFusedLine(u, out, g);
 }

--- a/src/cl/middle.cl
+++ b/src/cl/middle.cl
@@ -34,39 +34,312 @@
 #endif
 #endif
 
-// Read a line for tailFused or fftHin
-// This reads partially transposed datat as written by fftMiddleIn
-void readTailFusedLine(CP(T2) in, T2 *u, u32 line) {
-  // We go to some length here to avoid dividing by MIDDLE in address calculations.
-  // The transPos converted logical line number into physical memory line numbers
-  // using this formula:  memline = line / WIDTH + line % WIDTH * MIDDLE.
-  // We can compute the 0..9 component of address calculations as line / WIDTH,
-  // and the 0,10,20,30,..310 component as (line % WIDTH) % 32 = (line % 32),
-  // and the multiple of 320 component as (line % WIDTH) / 32
+// Parameters we may want to let user tune.  WIDTH other than 512 and 1K is untested.  SMALL_HEIGHT other than 256 and 512 is untested.
+#if AMDGPU
+#define PADDING 1					// Prefer padding to avoid bad strides
+#define MIDDLE_IN_LDS_TRANSPOSE (IN_WG >= 128)		// Radeon VII likes LDS transpose for larger workgroups
+#define MIDDLE_OUT_LDS_TRANSPOSE (OUT_WG >= 128)	// Radeon VII likes LDS transpose for larger workgroups
+#define PAD_SIZE 16					// Radeon VII likes 16 T2 values = 256 bytes 
+#endif
 
+// nVidia Titan V see no padding benefit, likes LDS transposes
+#if !AMDGPU
+#define PADDING 0					// Don't prefer padding to avoid bad strides
+#define MIDDLE_IN_LDS_TRANSPOSE 1			// nVidia likes LDS transpose
+#define MIDDLE_OUT_LDS_TRANSPOSE 1			// nVidia likes LDS transpose
+#define PAD_SIZE 8					// nVidia documentation indicates 8 T2 values = 128 bytes should be best
+#endif
+
+//****************************************************************************************
+// Pair of routines to write data from carryFused and read data into fftMiddleIn
+//****************************************************************************************
+
+// Optionally pad lines on output from fft_WIDTH in carryFused for input to fftMiddleIn.
+// This lets fftMiddleIn read a more varied distribution of addresses.
+// This can be faster on AMD GPUs, not certain about nVidia GPUs.
+
+// writeCarryFusedLine writes:
+//      x         ranges 0...WIDTH-1 (multiples of BIG_HEIGHT)		(also known as 0...WG-1 and 0...NW-1)
+//      line      ranges 0...BIG_HEIGHT-1 (multiples of one)
+// fftMiddleIn reads:
+//      x         ranges 0...WIDTH-1 (multiples of BIG_HEIGHT)
+//	u[i]	  i ranges 0...MIDDLE-1 (multiples of SMALL_HEIGHT)
+//      y         ranges 0...SMALL_HEIGHT-1 (multiples of one)
+
+void writeCarryFusedLine(T2 *u, P(T2) out, u32 line) {
+#if PADDING
+  out += line * WIDTH + line / SMALL_HEIGHT * PAD_SIZE + (u32) get_local_id(0);	// One padding every SMALL_HEIGHT lines
+  for (u32 i = 0; i < NW; ++i) { out[i * G_W] = u[i]; }
+#else
+  out += line * WIDTH + (u32) get_local_id(0);
+  for (u32 i = 0; i < NW; ++i) { out[i * G_W] = u[i]; }
+#endif
+}
+
+void readMiddleInLine(T2 *u, CP(T2) in, u32 y, u32 x) {
+#if PADDING
+  in += y * WIDTH + y / SMALL_HEIGHT * PAD_SIZE + x;
+  for (i32 i = 0; i < MIDDLE; ++i) { u[i] = in[i * (SMALL_HEIGHT * WIDTH + PAD_SIZE)]; }
+#else
+  in += y * WIDTH + x;
+  for (i32 i = 0; i < MIDDLE; ++i) { u[i] = in[i * SMALL_HEIGHT * WIDTH]; }
+#endif
+}
+
+//****************************************************************************************
+// Pair of routines to write data from fftMiddleIn and read data into tailFusedSquare/Mul
+//****************************************************************************************
+
+// fftMiddleIn processes:
+//      x         ranges 0...WIDTH-1 (multiples of BIG_HEIGHT)
+//	u[i]	  i ranges 0...MIDDLE-1 (multiples of SMALL_HEIGHT)
+//      y         ranges 0...SMALL_HEIGHT-1 (multiples of one)
+// tailFused reads:
+//      x         ranges 0...SMALL_HEIGHT-1 (multiples of one)		(also known as 0...G_H-1 and 0...NH-1)
+//      y         ranges 0...MIDDLE*WIDTH-1 (multiples of SMALL_HEIGHT)
+
+void writeMiddleInLine (P(T2) out, T2 *u, u32 chunk_y, u32 chunk_x)
+{
+  //u32 SIZEY = IN_WG / IN_SIZEX;
+  //u32 num_x_chunks = WIDTH / IN_SIZEX;		// Number of x chunks
+  //u32 num_y_chunks = SMALL_HEIGHT / SIZEY;		// Number of y chunks
+
+#if PADDING
+
+  u32 SIZEY = IN_WG / IN_SIZEX;
+
+  out += chunk_y * (MIDDLE * IN_WG + PAD_SIZE) +	// Write y chunks after middle chunks and a pad 
+         chunk_x * (SMALL_HEIGHT * MIDDLE * IN_SIZEX +	// num_y_chunks * (MIDDLE * IN_WG + PAD_SIZE)
+		    SMALL_HEIGHT / SIZEY * PAD_SIZE);	//              = SMALL_HEIGHT / SIZEY * (MIDDLE * IN_WG + PAD_SIZE)
+							//              = SMALL_HEIGHT / (IN_WG / IN_SIZEX) * (MIDDLE * IN_WG + PAD_SIZE)
+							//		= SMALL_HEIGHT * MIDDLE * IN_SIZEX + SMALL_HEIGHT / SIZEY * PAD_SIZE
+  // Write each u[i] sequentially
+  for (int i = 0; i < MIDDLE; ++i) { out[i * IN_WG] = u[i]; }
+
+#else
+
+  // Output data such that readCarryFused lines are packed tightly together.  No rotations or padding.
+  out += chunk_y * MIDDLE * IN_WG +			// Write y chunks after middles
+         chunk_x * MIDDLE * SMALL_HEIGHT * IN_SIZEX;	// num_y_chunks * IN_WG = SMALL_HEIGHT / SIZEY * MIDDLE * IN_WG
+							//                       = MIDDLE * SMALL_HEIGHT / (IN_WG / IN_SIZEX) * IN_WG
+							//                       = MIDDLE * SMALL_HEIGHT * IN_SIZEX
+  // Write each u[i] sequentially
+  for (int i = 0; i < MIDDLE; ++i) { out[i * IN_WG] = u[i]; }
+
+#endif
+}
+
+// Read a line for tailFused or fftHin
+// This reads partially transposed data as written by fftMiddleIn
+void readTailFusedLine(CP(T2) in, T2 *u, u32 line) {
   u32 me = get_local_id(0);
   u32 SIZEY = IN_WG / IN_SIZEX;
 
-  in += line / WIDTH * IN_WG;
-  in += line % IN_SIZEX * SIZEY;
-  in += line % WIDTH / IN_SIZEX * (SMALL_HEIGHT / SIZEY) * MIDDLE * IN_WG;
+#if PADDING
 
-  in += me / SIZEY * MIDDLE * IN_WG + me % SIZEY;
-  for (i32 i = 0; i < NH; ++i) { u[i] = in[i * G_H / SIZEY * MIDDLE * IN_WG]; }
+  // Adjust in pointer based on the x value used in writeMiddleInLine
+  u32 fftMiddleIn_x = line % WIDTH;				// The fftMiddleIn x value
+  u32 chunk_x = fftMiddleIn_x / IN_SIZEX;			// The fftMiddleIn chunk_x value
+  in += chunk_x * (SMALL_HEIGHT * MIDDLE * IN_SIZEX + SMALL_HEIGHT / SIZEY * PAD_SIZE);	// Adjust in pointer the same way writeMiddleInLine did
+  u32 x_within_in_wg = fftMiddleIn_x % IN_SIZEX;		// There were IN_SIZEX x values within IN_WG
+  in += x_within_in_wg * SIZEY;					// Adjust in pointer the same way writeMiddleInLine wrote x values within IN_WG
+
+  // Adjust in pointer based on the i value used in writeMiddleInLine
+  u32 fftMiddleIn_i = line / WIDTH;				// The i in fftMiddleIn's u[i]
+  in += fftMiddleIn_i * IN_WG;					// Adjust in pointer the same way writeMiddleInLine did
+
+  // Adjust in pointer based on the y value used in writeMiddleInLine
+  in += me % SIZEY;						// Adjust in pointer to read SIZEY consecutive values
+  for (i32 i = 0; i < NH; ++i) {
+    u32 fftMiddleIn_y = i * G_H + me;				// The fftMiddleIn y value
+    u32 chunk_y = fftMiddleIn_y / SIZEY;			// The fftMiddleIn chunk_y value
+    u[i] = in[chunk_y * (MIDDLE * IN_WG + PAD_SIZE)];		// Adjust in pointer the same way writeMiddleInLine did
+  }
+
+#else								// Read data that was not rotated or padded
+
+  // Adjust in pointer based on the x value used in writeMiddleInLine
+  u32 fftMiddleIn_x = line % WIDTH;				// The fftMiddleIn x value
+  u32 chunk_x = fftMiddleIn_x / IN_SIZEX;			// The fftMiddleIn chunk_x value
+  in += chunk_x * (SMALL_HEIGHT * MIDDLE * IN_SIZEX);		// Adjust in pointer the same way writeMiddleInLine did
+  u32 x_within_in_wg = fftMiddleIn_x % IN_SIZEX;		// There were IN_SIZEX x values within IN_WG
+  in += x_within_in_wg * SIZEY;					// Adjust in pointer the same way writeMiddleInLine wrote x values within IN_WG
+
+  // Adjust in pointer based on the i value used in writeMiddleInLine
+  u32 fftMiddleIn_i = line / WIDTH;				// The i in fftMiddleIn's u[i]
+  in += fftMiddleIn_i * IN_WG;					// Adjust in pointer the same way writeMiddleInLine did
+
+  // Adjust in pointer based on the y value used in writeMiddleInLine
+  in += me % SIZEY;						// Adjust in pointer to read SIZEY consecutive values
+  for (i32 i = 0; i < NH; ++i) {
+    u32 fftMiddleIn_y = i * G_H + me;				// The fftMiddleIn y value
+    u32 chunk_y = fftMiddleIn_y / SIZEY;			// The fftMiddleIn chunk_y value
+    u[i] = in[chunk_y * (MIDDLE * IN_WG)];			// Adjust in pointer the same way writeMiddleInLine did
+  }
+
+#endif
+}
+
+//****************************************************************************************
+// Pair of routines to write data from tailFusedSquare/Mul and read data into fftMiddleOut
+//****************************************************************************************
+
+// Optionally pad lines on output from fft_HEIGHT in tailFusedSquare/Mul for input to fftMiddleOut.
+// This lets fftMiddleOut read a more varied distribution of addresses.
+// This can be faster on AMD GPUs, not certain about nVidia GPUs.
+
+// tailFused writes:
+//      x         ranges 0...SMALL_HEIGHT-1 (multiples on one)		(also known as 0...G_H-1 and 0...NH-1)
+//      y         ranges 0...MIDDLE*WIDTH-1 (multiples of SMALL_HEIGHT)
+// fftMiddleOut reads:
+//      x         ranges 0...SMALL_HEIGHT-1 (multiples of one)		(processed in batches of OUT_SIZEX)
+//      i in u[i] ranges 0...MIDDLE-1 (multiples of SMALL_HEIGHT)
+//      y         ranges 0...WIDTH-1 (multiples of BIG_HEIGHT)		(processed in batches of OUT_WG/OUT_SIZEX)
+
+void writeTailFusedLine(T2 *u, P(T2) out, u32 line) {
+#if PADDING
+  out += line * (SMALL_HEIGHT + PAD_SIZE) + (u32) get_local_id(0);	// Pad every output line
+  for (u32 i = 0; i < NH; ++i) { out[i * G_H] = u[i]; }
+#else					                                // No padding, might be better on nVidia cards
+  out += line * SMALL_HEIGHT + (u32) get_local_id(0);
+  for (u32 i = 0; i < NH; ++i) { out[i * G_H] = u[i]; }
+#endif
+}
+
+void readMiddleOutLine(T2 *u, CP(T2) in, u32 y, u32 x) {
+#if PADDING
+  in += y * MIDDLE * (SMALL_HEIGHT + PAD_SIZE) + x;
+  for (i32 i = 0; i < MIDDLE; ++i) { u[i] = in[i * (SMALL_HEIGHT + PAD_SIZE)]; }
+#else									// No rotation, might be better on nVidia cards
+  in += y * MIDDLE * SMALL_HEIGHT + x;
+  for (i32 i = 0; i < MIDDLE; ++i) { u[i] = in[i * SMALL_HEIGHT]; }
+#endif
 }
 
 
-// Read a line for carryFused or FFTW
+//****************************************************************************************
+// Pair of routines to write data from fftMiddleOut and read data into carryFused
+//****************************************************************************************
+
+// Write data from fftMiddleOut for consumption by carryFusedLine.
+// We have the freedom to write the data anywhere in the output buffer,
+// so we want to select locations that help speed up readCarryFusedLine.
+//
+// This gets complicated very fast, so I've documented my thought processes here.
+// fftMiddleOut reads:
+//      x         ranges 0...SMALL_HEIGHT-1 (multiples of one)		(processed in batches of OUT_SIZEX)
+//      i in u[i] ranges 0...MIDDLE-1 (multiples of SMALL_HEIGHT)
+//      y         ranges 0...WIDTH-1 (multiples of BIG_HEIGHT)		(processed in batches of OUT_WG/OUT_SIZEX)
+// readCarryFusedLine reads:
+//      x         ranges 0...WIDTH-1 (multiples of BIG_HEIGHT)		(also known as 0...WG-1 and 0...NW-1)
+//      line      ranges 0...BIG_HEIGHT-1 (multiples of one)
+//
+// Of note above, all the (y,x) values where x is unchanged are read by a single readCarryFusedLine call.
+// Also, all the (y,x+1) values are read by the next readCarryFusedLine wavefront.  Since carryFused kernels are dispatched
+// in ascending order, it is beneficial to group the (y,x+1) pairs immediately after the (y,x) pairs in case the (y,x) values
+// are smaller than a full memory line.  The (y,x+1) pairs are then highly likely to be in the GPU's L2 cache.
+//
+// In the next sections we'll work through an example where WIDTH=1024, MIDDLE=15, SMALL_HEIGHT=256, OUT_WG=128, and OUT_SIZEX=16.
+// The first order of business is for fftMiddleOut to contiguously write all data values that will be needed for a single readCarryFusedLine.
+// That is, OUT_WG/OUT_SIZEX (y,x) values for the first x value (in our example this is 8 values - a value is data type T2 or 16 bytes, a total of 128 bytes).
+// As noted above, we then output the (y,x+1) values, (y,x+2) and so on OUT_SIZEX times.  A total of 16 * 128 = 2KB in our example.
+//
+// The next memory layout decision is whether we should either a) output the next set of y values (readCarryFused lines are tightly packed together),
+// or b) output the next set of x values (readCarryFused lines are spread out over a greater area) or c) the MIDDLE lines for sequential writes.
+// In our example, readCarryFusedLine will read from WIDTH/8=128 different 2KB chunks.  128 2KB strides sounds scary to me.  To get a variety of
+// strides we can rotate data within 2KB chunks or use a small padding less than 2KB.  A GPU is likely to prefer 128, 256, or 512 byte reads -- this
+// limits the number of rotation/padding options in a 2KB chunk to 16, 8, or just 4.  If we go with option (b) or (c) we can rotate data over a larger
+// area, but that is of no benefit as the stride will still be some multiple of 2KB.  If there are other bad stride values, (e.g. some CPUs don't like
+// 64KB strides) that could impact our decision here (e.g. option (c) with MIDDLE=16 would result in a 32KB stride).
+//
+// If we output all MIDDLE i values after the x and y values, there will be a huge power-of-two stride between these writes.
+// This is a problem on Radeon VII.  Another rotation or padding would be necessary.
+//
+// After experimentation, we've chosen to output the MIDDLE values next with padding (padding is simpler code than rotation).
+// Other options are workable with no measurable degradation in performance.
+
+// Caller must either give us u values that are grouped by x values (i.e. the order in which they were read in) with the out pointer
+// adjusted to effect a transpose.  Or caller must transpose the x and y values and send us an out pointer with thread_id added in.
+// In other words, caller is responsible for deciding the best way to transpose x and y values.
+
+void writeMiddleOutLine (P(T2) out, T2 *u, u32 chunk_y, u32 chunk_x)
+{
+  //u32 SIZEY = OUT_WG / OUT_SIZEX;
+  //u32 num_x_chunks = SMALL_HEIGHT / OUT_SIZEX;  // Number of x chunks
+  //u32 num_y_chunks = WIDTH / SIZEY;             // Number of y chunks
+
+#if PADDING
+
+  u32 SIZEY = OUT_WG / OUT_SIZEX;
+
+  out += chunk_y * (MIDDLE * OUT_WG + PAD_SIZE) +	// Write y chunks after middle chunks and a pad 
+         chunk_x * (WIDTH * MIDDLE * OUT_SIZEX +	// num_y_chunks * (MIDDLE * OUT_WG + PAD_SIZE)
+		    WIDTH / SIZEY * PAD_SIZE);		//              = WIDTH / SIZEY * (MIDDLE * OUT_WG + PAD_SIZE)
+							//              = WIDTH / (OUT_WG / OUT_SIZEX) * (MIDDLE * OUT_WG + PAD_SIZE)
+							//		= WIDTH * MIDDLE * OUT_SIZEX + WIDTH / SIZEY * PAD_SIZE
+  // Write each u[i] sequentially
+  for (int i = 0; i < MIDDLE; ++i) { out[i * OUT_WG] = u[i]; }
+
+#else
+
+  // Output data such that readCarryFused lines are packed tightly together.  No rotations or padding.
+  out += chunk_y * MIDDLE * OUT_WG +             // Write y chunks after middles
+         chunk_x * MIDDLE * WIDTH * OUT_SIZEX;   // num_y_chunks * OUT_WG = WIDTH / SIZEY * MIDDLE * OUT_WG
+                                        //                       = MIDDLE * WIDTH / (OUT_WG / OUT_SIZEX) * OUT_WG
+                                        //                       = MIDDLE * WIDTH * OUT_SIZEX
+  // Write each u[i] sequentially
+  for (int i = 0; i < MIDDLE; ++i) { out[i * OUT_WG] = u[i]; }
+
+#endif
+}
+
+// Read a line for carryFused or FFTW.  This line was written by writeMiddleOutLine above.
 void readCarryFusedLine(CP(T2) in, T2 *u, u32 line) {
   u32 me = get_local_id(0);
-  u32 WG = OUT_WG; // * OUT_SPACING;
-  u32 SIZEY = WG / OUT_SIZEX;
+  u32 SIZEY = OUT_WG / OUT_SIZEX;
 
-  in += line % OUT_SIZEX * SIZEY
-        + line % SMALL_HEIGHT / OUT_SIZEX * WIDTH / SIZEY * MIDDLE * WG
-        + line / SMALL_HEIGHT * WG;
+#if PADDING
 
-  in += me / SIZEY * MIDDLE * WG + me % SIZEY;
+  // Adjust in pointer based on the x value used in writeMiddleOutLine
+  u32 fftMiddleOut_x = line % SMALL_HEIGHT;			// The fftMiddleOut x value
+  u32 chunk_x = fftMiddleOut_x / OUT_SIZEX;			// The fftMiddleOut chunk_x value
+  in += chunk_x * (WIDTH * MIDDLE * OUT_SIZEX + WIDTH / SIZEY * PAD_SIZE);	// Adjust in pointer the same way writeMiddleOutLine did
+  u32 x_within_out_wg = fftMiddleOut_x % OUT_SIZEX;		// There were OUT_SIZEX x values within OUT_WG
+  in += x_within_out_wg * SIZEY;				// Adjust in pointer the same way writeMiddleOutLine wrote x values within OUT_WG
 
-  for (i32 i = 0; i < NW; ++i) { u[i] = in[i * G_W / SIZEY * MIDDLE * WG]; }
+  // Adjust in pointer based on the i value used in writeMiddleOutLine
+  u32 fftMiddleOut_i = line / SMALL_HEIGHT;			// The i in fftMiddleOut's u[i]
+  in += fftMiddleOut_i * OUT_WG;				// Adjust in pointer the same way writeMiddleOutLine did
+
+  // Adjust in pointer based on the y value used in writeMiddleOutLine
+  in += me % SIZEY;						// Adjust in pointer to read SIZEY consecutive values
+  for (i32 i = 0; i < NW; ++i) {
+    u32 fftMiddleOut_y = i * G_W + me;				// The fftMiddleOut y value
+    u32 chunk_y = fftMiddleOut_y / SIZEY;			// The fftMiddleOut chunk_y value
+    u[i] = in[chunk_y * (MIDDLE * OUT_WG + PAD_SIZE)];		// Adjust in pointer the same way writeMiddleOutLine did
+  }
+
+#else								// Read data that was not rotated or padded
+
+  // Adjust in pointer based on the x value used in writeMiddleOutLine
+  u32 fftMiddleOut_x = line % SMALL_HEIGHT;			// The fftMiddleOut x value
+  u32 chunk_x = fftMiddleOut_x / OUT_SIZEX;			// The fftMiddleOut chunk_x value
+  in += chunk_x * MIDDLE * WIDTH * OUT_SIZEX;			// Adjust in pointer the same way writeMiddleOutLine did
+  u32 x_within_out_wg = fftMiddleOut_x % OUT_SIZEX;		// There were OUT_SIZEX x values within OUT_WG
+  in += x_within_out_wg * SIZEY;				// Adjust in pointer the same way writeMiddleOutLine wrote x values with OUT_WG
+
+  // Adjust in pointer based on the i value used in writeMiddleOutLine
+  u32 fftMiddleOut_i = line / SMALL_HEIGHT;			// The i in fftMiddleOut's u[i]
+  in += fftMiddleOut_i * OUT_WG;				// Adjust in pointer the same way writeMiddleOutLine did
+
+  // Adjust in pointer based on the y value used in writeMiddleOutLine
+  in += me % SIZEY;						// Adjust in pointer to read SIZEY consecutive values
+  for (i32 i = 0; i < NW; ++i) {
+    u32 fftMiddleOut_y = i * G_W + me;				// The fftMiddleOut y value
+    u32 chunk_y = fftMiddleOut_y / SIZEY;			// The fftMiddleOut chunk_y value
+    u[i] = in[chunk_y * MIDDLE * OUT_WG];			// Adjust in pointer the same way writeMiddleOutLine did
+  }
+
+#endif
+
 }

--- a/src/cl/tailmul.cl
+++ b/src/cl/tailmul.cl
@@ -122,6 +122,6 @@ KERNEL(G_H) tailMul(P(T2) out, CP(T2) in, CP(T2) a, Trig smallTrig) {
   fft_HEIGHT(lds, v, smallTrig, w);
   bar();
   fft_HEIGHT(lds, u, smallTrig, w);
-  writeRotatedHeight(G_H, NH, v, out, memline2);
-  writeRotatedHeight(G_H, NH, u, out, memline1);
+  writeTailFusedLine(v, out, memline2);
+  writeTailFusedLine(u, out, memline1);
 }

--- a/src/cl/tailsquare.cl
+++ b/src/cl/tailsquare.cl
@@ -103,6 +103,6 @@ KERNEL(G_H) tailSquare(P(T2) out, CP(T2) in, Trig smallTrig) {
   fft_HEIGHT(lds, v, smallTrig, w);
   bar();
   fft_HEIGHT(lds, u, smallTrig, w);
-  writeRotatedHeight(G_H, NH, v, out, memline2);
-  writeRotatedHeight(G_H, NH, u, out, memline1);
+  writeTailFusedLine(v, out, memline2);
+  writeTailFusedLine(u, out, memline1);
 }


### PR DESCRIPTION
Replaced rotates with simpler and slightly faster padding.
Moved rotate code to middle.in with new consistent names.