### PR TITLE
Attempt to make PRPLL compatible with AutoPrimeNet

### DIFF
--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -115,12 +115,10 @@ and should be able to run.
 
 
 Worktodo:
-PRPLL keeps the active tasks in per-worker files worktodo-0.txt, worktodo-1.txt etc in the local directory.
-These per-worker files are supplied from the global worktodo.txt file if -pool is used.
-In turn the global worktodo.txt can be supplied through the primenet.py script,
-either the one located at gpuowl/tools/primenet.py or https://download.mersenne.ca/primenet.py
-
-It is also possible to manually add exponents by adding lines of the form "PRP=118063003" to worktodo-<N>.txt
+PRPLL keeps the active tasks in worktodo.txt files in per-worker directories: worker-0, worker-1 etc.
+Per-worker worktodo.txt can be supplied through the primenet.py script, either the one located at
+gpuowl/tools/primenet.py or https://download.mersenne.ca/primenet.py
+It is possible to manually add exponents by adding lines of the form "PRP=118063003" to worktodo.txt
 
 
 The configuration options listed below can be passed on the command line or can be put in a file
@@ -130,9 +128,6 @@ named "config.txt" in the prpll run directory.
 -h                 : print general help, list of FFTs, list of devices
 -info <fft>        : print detailed information about the given FFT; e.g. -h 1K:13:256
 -dir <folder>      : specify local work directory (containing worktodo.txt, results.txt, config.txt, gpuowl.log)
--pool <dir>        : specify a directory with the shared (pooled) worktodo.txt and results.txt
-                     Multiple PRPLL instances, each in its own directory, can share a pool of assignments and report
-                     the results back to the common pool.
 -verbose           : print more log, useful for developers
 -version           : print only the version and exit
 -user <name>       : specify the mersenne.org user name (for result reporting)
@@ -350,13 +345,6 @@ void Args::parse(const string& line) {
       }
       verifyPath = s;
     }
-    else if (key == "-pool") {
-      masterDir = s;
-      if (!masterDir.is_absolute()) {
-        log("-pool <path> requires an absolute path\n");
-        throw("-pool <path> requires an absolute path");
-      }
-    }
     else if (key == "-results") { resultsFile = s; }
     else if (key == "-maxAlloc" || key == "-maxalloc") {
       assert(!s.empty());
@@ -408,15 +396,17 @@ void Args::parse(const string& line) {
 void Args::setDefaults() {
   uid = getUidFromPos(device);
   log("device %d, OpenCL %s, unique id '%s'\n", device, getDriverVersionByPos(device).c_str(), uid.c_str());
-  
-  if (!masterDir.empty()) {
-    assert(masterDir.is_absolute());
-    for (filesystem::path* p : {&proofResultDir, &proofToVerifyDir, &cacheDir, &resultsFile}) {
-      if (p->is_relative()) { *p = masterDir / *p; }
-    }
+
+  fs::create_directory(cacheDir);
+
+  for (u32 i = 0; i < workers; ++i) {
+    fs::path worker = "worker-" + to_string(i);
+    fs::create_directory(worker);
+
+    fs::create_directory(worker / proofResultDir);
+    fs::create_directory(worker / proofToVerifyDir);
+
+    File::openAppend(worker / resultsFile);  // verify that it's possible to write results
   }
 
-  for (auto& p : {proofResultDir, proofToVerifyDir, cacheDir}) { fs::create_directory(p); }
-
-  File::openAppend(resultsFile);  // verify that it's possible to write results
 }

--- a/src/Args.h
+++ b/src/Args.h
@@ -62,7 +62,6 @@ public:
   bool useCache = false;
   bool profile = false;
 
-  fs::path masterDir;
   fs::path proofResultDir = "proof";
   fs::path proofToVerifyDir = "proof-tmp";
   fs::path cacheDir = "kernel-cache";

--- a/src/Gpu.h
+++ b/src/Gpu.h
@@ -237,7 +237,7 @@ private:
 
   void modMul(Buffer<int>& ioA, Buffer<int>& inB, bool mul3 = false);
   
-  fs::path saveProof(const Args& args, const ProofSet& proofSet);
+  fs::path saveProof(const Args& args, const ProofSet& proofSet, u32 instance);
   std::pair<RoeInfo, RoeInfo> readROE();
   RoeInfo readCarryStats();
   
@@ -260,8 +260,8 @@ public:
 
   ~Gpu();
 
-  PRPResult isPrimePRP(const Task& task);
-  LLResult isPrimeLL(const Task& task);
+  PRPResult isPrimePRP(const Task& task, u32 instance);
+  LLResult isPrimeLL(const Task& task, u32 instance);
   array<u64, 4> isCERT(const Task& task);
 
   double timePRP();
@@ -269,7 +269,7 @@ public:
   tuple<bool, u64, RoeInfo, RoeInfo> measureROE(bool quick);
   tuple<bool, RoeInfo> measureCarry();
 
-  Saver<PRPState> *getSaver();
+  Saver<PRPState> *getSaver(u32 instance);
 
   void carryA(Buffer<double>& a, Buffer<double>& b) { carryA(reinterpret_cast<Buffer<int>&>(a), b); }
 
@@ -314,9 +314,9 @@ public:
   Words expExp2(const Words& A, u32 n);
   vector<Buffer<i32>> makeBufVector(u32 size);
 
-  void clear(bool isPRP);
+  void clear(bool isPRP, u32 instance);
 
 private:
-  u32 getProofPower(u32 k);
+  u32 getProofPower(u32 k, u32 instance);
   void doBigLog(u32 k, u64 res, bool checkOK, float secsPerIt, u32 nIters, u32 nErrors);
 };

--- a/src/Proof.h
+++ b/src/Proof.h
@@ -55,35 +55,39 @@ class ProofSet {
 public:
   const u32 E;
   const u32 power;
+  const u32 instance;
   
 private:  
   vector<u32> points;  
   
   bool isValidTo(u32 limitK) const;
 
-  static bool canDo(u32 E, u32 power, u32 currentK);
+  static bool canDo(u32 E, u32 power, u32 currentK, u32 instance);
 
   mutable decltype(points)::const_iterator cacheIt{};
 
   bool fileExists(u32 k) const;
 
-  static fs::path proofPath(u32 E) { return fs::path(to_string(E)) / "proof"; }
+  static fs::path proofPath(u32 E, u32 instance) {
+    fs::path worker = "worker-" + to_string(instance);
+    return fs::path(worker / to_string(E)) / "proof";
+  }
 public:
   
   static u32 bestPower(u32 E);
-  static u32 effectivePower(u32 E, u32 power, u32 currentK);
+  static u32 effectivePower(u32 E, u32 power, u32 currentK, u32 instance);
   static double diskUsageGB(u32 E, u32 power);
   static bool isInPoints(u32 E, u32 power, u32 k);
   
-  ProofSet(u32 E, u32 power);
+  ProofSet(u32 E, u32 power, u32 instance);
     
   u32 next(u32 k) const;
 
-  static void save(u32 E, u32 power, u32 k, const Words& words);
-  static Words load(u32 E, u32 power, u32 k);
+  static void save(u32 E, u32 power, u32 k, const Words& words, u32 instance);
+  static Words load(u32 E, u32 power, u32 k, u32 instance);
         
-  void save(u32 k, const Words& words) const { return save(E, power, k, words); }
-  Words load(u32 k) const { return load(E, power, k); }
+  void save(u32 k, const Words& words) const { return save(E, power, k, words, instance); }
+  Words load(u32 k) const { return load(E, power, k, instance); }
 
 
   std::pair<Proof, vector<u64>> computeProof(Gpu *gpu) const;

--- a/src/Saver.cpp
+++ b/src/Saver.cpp
@@ -169,7 +169,7 @@ template<> LLState Saver<LLState>::initState() {
 // ---- Saver ----
 
 template<typename State>
-Saver<State>::Saver(u32 exponent, u32 blockSize, u32 nSavefiles) :
+Saver<State>::Saver(u32 exponent, u32 blockSize, u32 nSavefiles, u32 instance) :
   exponent{exponent},
   blockSize{blockSize},
   prefix{to_string(exponent) + '-'},
@@ -177,9 +177,11 @@ Saver<State>::Saver(u32 exponent, u32 blockSize, u32 nSavefiles) :
 {
   assert(blockSize && (blockSize % 100 == 0) && (10'000 % blockSize == 0));
 
+  fs::path worker = "worker-" + to_string(instance);
+
   base = std::is_same_v<State, PRPState> ?
-        fs::current_path() / to_string(exponent)
-      : fs::current_path() / (string(State::KIND) + '-' + to_string(exponent));
+        fs::current_path() / worker / to_string(exponent)
+      : fs::current_path() / worker / (string(State::KIND) + '-' + to_string(exponent));
 
   if (!fs::exists(base)) { fs::create_directories(base); }
 }
@@ -188,11 +190,12 @@ template<typename State>
 Saver<State>::~Saver() = default;
 
 template<typename State>
-void Saver<State>::clear(u32 exponent) {
+void Saver<State>::clear(u32 exponent, u32 instance) {
   error_code dummy;
+  fs::path worker = "worker-" + to_string(instance);
   fs::path base = std::is_same_v<State, PRPState> ?
-        fs::current_path() / to_string(exponent)
-      : fs::current_path() / (string(State::KIND) + '-' + to_string(exponent));
+        fs::current_path() / worker / to_string(exponent)
+      : fs::current_path() / worker / (string(State::KIND) + '-' + to_string(exponent));
   fs::remove_all(base, dummy);
 }
 

--- a/src/Saver.h
+++ b/src/Saver.h
@@ -45,7 +45,7 @@ class Saver {
   fs::path mostRecentSavefile();
 
 public:
-  Saver(u32 exponent, u32 blockSize, u32 nSavefiles);
+  Saver(u32 exponent, u32 blockSize, u32 nSavefiles, u32 instance);
   ~Saver();
 
   State load();
@@ -53,7 +53,7 @@ public:
 
   void dropMostRecent();
 
-  static void clear(u32 exponent);
+  static void clear(u32 exponent, u32 instance);
 
   // For PRP, we can save a verified save (see save() above) or an unverified save.
   void saveUnverified(const PRPState& s) const;

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -133,18 +133,20 @@ vector<string> tailFields(const std::string &AID, const Args &args) {
 }
 
 void writeResult(u32 E, const char *workType, const string &status, const std::string &AID, const Args &args,
-                 const vector<string>& extras) {
+                 const vector<string>& extras, u32 instance) {
   vector<string> fields = commonFields(E, workType, status);
   fields += extras;
   fields += tailFields(AID, args);
   string s = json(std::move(fields));
   log("%s\n", s.c_str());
-  File::append(args.resultsFile, s + '\n');
+
+  fs::path worker = "worker-" + to_string(instance);
+  File::append(worker / args.resultsFile, s + '\n');
 }
 
 }
 
-void Task::writeResultPRP(const Args &args, bool isPrime, u64 res64, const string& res2048, u32 fftSize, u32 nErrors, const fs::path& proofPath) const {
+void Task::writeResultPRP(const Args &args, bool isPrime, u64 res64, const string& res2048, u32 fftSize, u32 nErrors, const fs::path& proofPath, u32 instance) const {
   vector<string> fields{json("res64", hex(res64)),
                         json("res2048", res2048),
                         json("residue-type", 1),
@@ -165,20 +167,20 @@ void Task::writeResultPRP(const Args &args, bool isPrime, u64 res64, const strin
     }
   }
   
-  writeResult(exponent, "PRP-3", isPrime ? "P" : "C", AID, args, fields);
+  writeResult(exponent, "PRP-3", isPrime ? "P" : "C", AID, args, fields, instance);
 }
 
-void Task::writeResultLL(const Args &args, bool isPrime, u64 res64, u32 fftSize) const {
+void Task::writeResultLL(const Args &args, bool isPrime, u64 res64, u32 fftSize, u32 instance) const {
   vector<string> fields{json("res64", hex(res64)),
                         json("fft-length", fftSize),
                         json("shift-count", 0),
                         json("error-code", "00000000"), // I don't know the meaning of this
   };
 
-  writeResult(exponent, "LL", isPrime ? "P" : "C", AID, args, fields);
+  writeResult(exponent, "LL", isPrime ? "P" : "C", AID, args, fields, instance);
 }
 
-void Task::writeResultCERT(const Args &args, array <u64, 4> hash, u32 squarings, u32 fftSize) const {
+void Task::writeResultCERT(const Args &args, array <u64, 4> hash, u32 squarings, u32 fftSize, u32 instance) const {
   string hexhash = hex(hash[3]) + hex(hash[2]) + hex(hash[1]) + hex(hash[0]);
   vector<string> fields{json("worktype", "Cert"),
 			json("exponent", exponent),
@@ -191,7 +193,8 @@ void Task::writeResultCERT(const Args &args, array <u64, 4> hash, u32 squarings,
   fields += tailFields(AID, args);
   string s = json(std::move(fields));
   log("%s\n", s.c_str());
-  File::append(args.resultsFile, s + '\n');
+  fs::path worker = "worker-" + to_string(instance);
+  File::append(worker / args.resultsFile, s + '\n');
 }
 
 void Task::execute(GpuCommon shared, Queue *q, u32 instance) {
@@ -214,13 +217,13 @@ void Task::execute(GpuCommon shared, Queue *q, u32 instance) {
   } else if (kind == PRP || kind == LL) {
     bool isPrime;
     if (kind == PRP) {
-      auto [tmpIsPrime, res64, nErrors, proofPath, res2048] = gpu->isPrimePRP(*this);
+      auto [tmpIsPrime, res64, nErrors, proofPath, res2048] = gpu->isPrimePRP(*this, instance);
       isPrime = tmpIsPrime;
-      writeResultPRP(*shared.args, isPrime, res64, res2048, fft.size(), nErrors, proofPath);
+      writeResultPRP(*shared.args, isPrime, res64, res2048, fft.size(), nErrors, proofPath, instance);
     } else { // LL
-      auto [tmpIsPrime, res64] = gpu->isPrimeLL(*this);
+      auto [tmpIsPrime, res64] = gpu->isPrimeLL(*this, instance);
       isPrime = tmpIsPrime;
-      writeResultLL(*shared.args, isPrime, res64, fft.size());
+      writeResultLL(*shared.args, isPrime, res64, fft.size(), instance);
     }
 
     Worktodo::deleteTask(*this, instance);
@@ -228,11 +231,11 @@ void Task::execute(GpuCommon shared, Queue *q, u32 instance) {
     if (isPrime) {
       log("%u is PRIME!\n", exponent);
     } else {
-      gpu->clear(kind == PRP);
+      gpu->clear(kind == PRP, instance);
     }
   } else if (kind == CERT) {
     auto sha256 = gpu->isCERT(*this);
-    writeResultCERT(*shared.args, sha256, squarings, fft.size());
+    writeResultCERT(*shared.args, sha256, squarings, fft.size(), instance);
     Worktodo::deleteTask(*this, instance);
   } else {
     throw "Unexpected task kind " + to_string(kind);

--- a/src/Task.h
+++ b/src/Task.h
@@ -27,7 +27,7 @@ public:
   string verifyPath; // For Verify
   void execute(GpuCommon shared, Queue* q, u32 instance);
 
-  void writeResultPRP(const Args&, bool isPrime, u64 res64, const std::string& res2048, u32 fftSize, u32 nErrors, const fs::path& proofPath) const;
-  void writeResultLL(const Args&, bool isPrime, u64 res64, u32 fftSize) const;
-  void writeResultCERT(const Args&, array <u64, 4> hash, u32 squarings, u32 fftSize) const;
+  void writeResultPRP(const Args&, bool isPrime, u64 res64, const std::string& res2048, u32 fftSize, u32 nErrors, const fs::path& proofPath, u32 instance) const;
+  void writeResultLL(const Args&, bool isPrime, u64 res64, u32 fftSize, u32 instance) const;
+  void writeResultCERT(const Args&, array <u64, 4> hash, u32 squarings, u32 fftSize, u32 instance) const;
 };

--- a/src/TuneEntry.cpp
+++ b/src/TuneEntry.cpp
@@ -41,9 +41,6 @@ bool TuneEntry::willUpdate(const vector<TuneEntry>& results) const {
 
 vector<TuneEntry> TuneEntry::readTuneFile(const Args& args) {
   fs::path tuneFile = "tune.txt";
-  if (!fs::exists(tuneFile)) {
-    tuneFile = args.masterDir / "tune.txt";
-  }
 
   // if (!fs::exists(tuneFile)) { log("Tune file %s not found\n", tuneFile.string().c_str()); }
 

--- a/src/Worktodo.cpp
+++ b/src/Worktodo.cpp
@@ -92,73 +92,36 @@ std::optional<Task> parse(const std::string& line) {
   return {};
 }
 
-// Among the valid tasks from fileName, return the "best" which means the smallest CERT, or otherwise the exponent PRP/LL
+// Among the valid tasks from fileName, return the "best" which means the smallest CERT, or otherwise the first available PRP/LL
 static std::optional<Task> bestTask(const fs::path& fileName) {
-  optional<Task> best;
+  optional<Task> bestCert;
+  optional<Task> firstNonCert;
   for (const string& line : File::openRead(fileName)) {
     optional<Task> task = parse(line);
-    if (task && (!best
-                 || (best->kind != Task::CERT && task->kind == Task::CERT)
-                 || ((best->kind != Task::CERT || task->kind == Task::CERT) && task->exponent < best->exponent))) {
-      best = task;
+    if (task) {
+      if (task->kind == Task::CERT) {
+        if (!bestCert || task->exponent < bestCert->exponent) {
+          bestCert = task;
+        }
+      } else if (!firstNonCert) {
+        firstNonCert = task;
+      }
     }
   }
-  return best;
+  return bestCert ? bestCert : firstNonCert;
 }
 
-string workName(i32 instance) { return "worktodo-" + to_string(instance) + ".txt"; }
+fs::path workFile(i32 instance) {
+  fs::path worker = "worker-" + to_string(instance);
+  return worker / "worktodo.txt";
+}
 
 optional<Task> getWork(Args& args, i32 instance) {
-  fs::path localWork = workName(instance);
+  fs::path localWork = workFile(instance);
 
-  // Try to get a task from the local worktodo-<N> file.
+  // Try to get a task from the worker-<n>/worktodo.txt file.
   if (optional<Task> task = bestTask(localWork)) { return task; }
 
-  if (args.masterDir.empty()) { return {}; }
-
-  fs::path worktodo = args.masterDir / "worktodo.txt";
-
-  /*
-    We need to aquire a task from the global worktodo.txt, and "atomically"
-    add the task to the local worktodo-N.txt and remove it from worktodo.txt
-
-    Below we call the global worktodo.txt "global worktodo", and worktodo-N.txt "local worktodo".
-
-    We want to avoid filesystem-based locking, so we approximate it this way:
-    1. read the file-size of the global worktodo
-    2. read one task from the global worktodo
-    3. append the task to the local worktodo
-    4. write the new content of the global worktodo without the task to a temporary file
-    5. compare the size of the global worktodo with its initial size (as an heuristic to detect modifications to it)
-    6a. if the size is not changed, rename the temporary file to global worktodo and done
-    6b. if the size is changed (i.e. global worktodo was modified in the meantime):
-       7. remove the task from the local worktodo (undo the local task add)
-       8. start again (from step 1)
-  */
-
-  for (int retry = 0; retry < 2; ++retry) {
-    u64 initialSize = fileSize(worktodo);
-    if (!initialSize) { return {}; }
-
-    optional<Task> task = bestTask(worktodo);
-    if (!task) { return {}; }
-
-    string workLine = task->line;
-    File::append(localWork, workLine);
-
-    if (deleteLine(worktodo, workLine, initialSize)) {
-      return task;
-    }
-
-    // Undo add to local worktodo. Attempt twice.
-    bool found = deleteLine(localWork, workLine) || deleteLine(localWork, workLine);
-    assert(found);
-    if (!found) { return {}; }
-  }
-
-  log("Could not extract a task from '%s'\n", worktodo.string().c_str());
-  // must be tough luck to be preempted twice while mutating the global worktodo
-  assert(false);
   return {};
 }
 
@@ -186,5 +149,5 @@ std::optional<Task> Worktodo::getTask(Args &args, i32 instance) {
 bool Worktodo::deleteTask(const Task &task, i32 instance) {
   // Some tasks don't originate in worktodo.txt and thus don't need deleting.
   if (task.line.empty()) { return true; }
-  return deleteLine(workName(instance), task.line);
+  return deleteLine(workFile(instance), task.line);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,7 @@ void gpuWorker(GpuCommon shared, Queue *q, i32 instance) {
   // LogContext context{(instance ? shared.args->tailDir() : ""s) + to_string(instance) + ' '};
   // log("Starting worker %d\n", instance);
   if (instance > 0) {
-    initLog(("gpuowl-"s + to_string(instance) + ".log").c_str());
+    initLog(("worker-"s + to_string(instance) + "/gpuowl.log").c_str());
     log("PRPLL %s, instance %d\n", VERSION, instance);
   }
 
@@ -67,20 +67,12 @@ int main(int argc, char **argv) {
       }
     }
     
-    fs::path poolDir;
-    {
-      Args args{true};
-      args.readConfig("config.txt");
-      args.parse(mainLine);
-      poolDir = args.masterDir;
-    }
-        
-    initLog("gpuowl-0.log");
+    fs::create_directory("worker-0");
+    initLog("worker-0/gpuowl.log");
     log("PRPLL %s starting\n", VERSION);
     
     Args args;
 
-    if (!poolDir.empty()) { args.readConfig(poolDir / "config.txt"); }
     args.readConfig("config.txt");
     args.parse(mainLine);
     args.setDefaults();


### PR DESCRIPTION
I made an attempt to make PRPLL compatible with AutoPrimeNet. Initially I made this changes for my own use, but then decided to make a pull request here. I don't think this is ready to be merged as is. However, I would like to know if there is an interest to continue this work.

Currently, PRPLL reads tasks from the per-worker `worktodo-<n>.txt` files and writes logs to per-worker `gpuowl-<n>.log` files, but writes results to a common `results.txt` file.  

This pull request makes PRPLL to create separate directories for each worker: `worker-0`, `worker-1` etc. Within each of this directories, it uses standard `worktodo.txt`, `results.txt` and `gpuowl.log` files. This way, it is possible to use PRPLL with the current version of AutoPrimeNet, by selecting GpuOwl as a used porogram and by pointing AutoPrimeNet to each worker's  directory.

Warning: currently, this pull request removes support for the `-pool` option. I am not sure how this option should interact with the layout described above. This option is also not compatible with AutoPrimeNet, as I understand it.