### PR TITLE
Added -use for NONTEMPORAL

### DIFF
--- a/src/Gpu.cpp
+++ b/src/Gpu.cpp
@@ -213,7 +213,8 @@ string clDefines(const Args& args, cl_device_id id, FFTConfig fft, const vector<
                               "DEBUG",
                               "CARRY64",
                               "BCAST",
-                              "BIGLIT"
+                              "BIGLIT",
+                              "NONTEMPORAL"
                             });
     if (!isValid) {
       log("Warning: unrecognized -use key '%s'\n", k.c_str());


### PR DESCRIPTION
I added an option to change non-temporal memory access from the command line. The default is off even though on Radeon VII it is about a 0.5% gaain. I suspect an A100 or recent AMD consumer cards with large caches will see bigger gains without nontemporal access.  We could change the default setting to depend on the cache size reported by clinfo.
In either case, we should make -tune auto-config this option.