### PR TITLE
-use PAD

### DIFF
--- a/src/Gpu.cpp
+++ b/src/Gpu.cpp
@@ -214,7 +214,8 @@ string clDefines(const Args& args, cl_device_id id, FFTConfig fft, const vector<
                               "CARRY64",
                               "BCAST",
                               "BIGLIT",
-                              "NONTEMPORAL"
+                              "NONTEMPORAL",
+                              "PAD"
                             });
     if (!isValid) {
       log("Warning: unrecognized -use key '%s'\n", k.c_str());
@@ -476,7 +477,7 @@ Gpu::Gpu(Queue* q, GpuCommon shared, FFTConfig fft, u32 E, const vector<KeyVal>&
   BUF(bufROE, ROE_SIZE),
   BUF(bufStatsCarry, CARRY_SIZE),
 
-  BUF(buf1, N + N/4),		// Let's us play with padding instead of rotating.  Need to calculate actual cost of padding
+  BUF(buf1, N + N/4),           // Let's us play with padding instead of rotating.  Need to calculate actual cost of padding
   BUF(buf2, N + N/4),
   BUF(buf3, N + N/4),
 #undef BUF

--- a/src/Gpu.cpp
+++ b/src/Gpu.cpp
@@ -213,7 +213,8 @@ string clDefines(const Args& args, cl_device_id id, FFTConfig fft, const vector<
                               "DEBUG",
                               "CARRY64",
                               "BCAST",
-                              "BIGLIT"
+                              "BIGLIT",
+                              "NONTEMPORAL"
                             });
     if (!isValid) {
       log("Warning: unrecognized -use key '%s'\n", k.c_str());

--- a/src/cl/carryfused.cl
+++ b/src/cl/carryfused.cl
@@ -39,6 +39,10 @@ KERNEL(G_W) carryFused(P(T2) out, CP(T2) in, u32 posROE, P(i64) carryShuttle, P(
 #undef GPW
 #endif
 
+// Try this weird FFT_width call that adds a "hidden zero" when unrolling.  This prevents the compiler from finding
+// common sub-expressions to re-use in the second fft_WIDTH call.  Re-using this data requires dozens of VGPRs
+// which causes a terrible reduction in occupancy.
+//  fft_WIDTH(lds + (get_group_id(0) / 131072), u, smallTrig + (get_group_id(0) / 131072));
   fft_WIDTH(lds, u, smallTrig);
 
   Word2 wu[NW];

--- a/src/cl/middle.cl
+++ b/src/cl/middle.cl
@@ -16,20 +16,30 @@
 #define OUT_SIZEX 16
 #endif
 
-// Parameters we may want to let user tune.  WIDTH other than 512 and 1K is untested.  SMALL_HEIGHT other than 256 and 512 is untested.
+// Let user control whether padding is enabled with -use PAD=0 or -use PAD=1.
+// The default is padding is on for AMD GPUs and off for others.
+// I do not know the correct setting for Intel BattleMage and I only have data on one nVidia GPU - the Titan V.
+#if !defined(PAD)
 #if AMDGPU
+#define PAD  1
+#else
+#define PAD  0
+#endif
+#endif
+   
+// Padding parameters we may want to let user tune.  WIDTH other than 512 and 1K is untested.  SMALL_HEIGHT other than 256 and 512 is untested.
+#if PAD
 #define PADDING 1                                       // Prefer padding to avoid bad strides
 #define MIDDLE_IN_LDS_TRANSPOSE (IN_WG >= 128)          // Radeon VII likes LDS transpose for larger workgroups
 #define MIDDLE_OUT_LDS_TRANSPOSE (OUT_WG >= 128)        // Radeon VII likes LDS transpose for larger workgroups
 #define PAD_SIZE 16                                     // Radeon VII likes 16 T2 values = 256 bytes 
-#endif
 
-// nVidia Titan V see no padding benefit, likes LDS transposes
-#if !AMDGPU
+// nVidia Titan V sees no padding benefit, likes LDS transposes
+#else
 #define PADDING 0                                       // Don't prefer padding to avoid bad strides
 #define MIDDLE_IN_LDS_TRANSPOSE 1                       // nVidia likes LDS transpose
 #define MIDDLE_OUT_LDS_TRANSPOSE 1                      // nVidia likes LDS transpose
-#define PAD_SIZE 8                                      // nVidia documentation indicates 8 T2 values = 128 bytes should be best
+#define PAD_SIZE 8                                      // nVidia documentation indicates 8 T2 values = 128 bytes ought to be best if we ever turn padding on
 #endif
 
 //****************************************************************************************


### PR DESCRIPTION
Two tiny changes.    We need to learn if Intel Battlemage benefits from padding.  Documented alternate fft_WIDTH call ffor use when unrolling.