### PR TITLE
Use portable _Float128 instead of __float128. Fix ARM64 builds.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -11,7 +11,7 @@ using i32 = int32_t;
 using u32 = uint32_t;
 using i64 = int64_t;
 using u64 = uint64_t;
-using f128 = __float128;
+using f128 = _Float128;
 
 static_assert(sizeof(u8)  == 1, "size u8");
 static_assert(sizeof(u32) == 4, "size u32");


### PR DESCRIPTION
Hello,

_( This fixes currently broken builds for ARM64 arch. )_

From https://gcc.gnu.org/onlinedocs/gcc/Floating-Types.html:

> __float128 is available on i386, x86_64, IA-64, LoongArch and hppa HP-UX, as well as on PowerPC GNU/Linux targets that enable the vector scalar (VSX) instruction set. __float128 supports the 128-bit floating type. On i386, x86_64, PowerPC, LoongArch and IA-64, other than HP-UX, __float128 is an alias for _Float128. On hppa and IA-64 HP-UX, __float128 is an alias for long double.

I.e. __float128 aren't portable, as it's not available on every platform. ARM64 aka aarch64 are the example platform without __float128. While _Float128 are standard and main platforms just alias __float128 to _Float128 anyways. 

This fixes building for ARM64 with GCC. I've tested under Ubuntu 25.x / gcc-14.x and main branch for prpll.

In case there are some reasons to have __float128 here, I can change this patch to add conditional alias __float128 -> _Float128 only if __aarch64__ macro defined.