### PR TITLE
Make PRPLL compatible with AutoPrimeNet 1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ build-*
 src/version.inc
 *.log
 t?
-results.txt
+results-*.txt
 kernel-cache
 prp-*/
 ll-*/

--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -154,7 +154,6 @@ named "config.txt" in the prpll run directory.
                      A lower power reduces disk space requirements but increases the verification cost.
                      A higher power increases disk usage a lot.
                      e.g. proof power 10 for a 120M exponent uses about %.0fGB of disk space.
--results <file>    : name of results file, default '%s'
 -iters <N>         : run next PRP test for <N> iterations and exit. Multiple of 10000.
 -save <N>          : specify the number of savefiles to keep (default %u).
 -noclean           : do not delete data after the test is complete.
@@ -212,7 +211,7 @@ named "config.txt" in the prpll run directory.
 
 Device selection : use one of -uid <UID>, -pci <BDF>, -device <N>, see the list below
 
-)", ProofSet::diskUsageGB(120000000, 10), resultsFile.string().c_str(), nSavefiles);
+)", ProofSet::diskUsageGB(120000000, 10), nSavefiles);
 
   vector<cl_device_id> deviceIds = getAllDeviceIDs();
   if (!deviceIds.empty()) {
@@ -352,7 +351,6 @@ void Args::parse(const string& line) {
       }
       verifyPath = s;
     }
-    else if (key == "-results") { resultsFile = s; }
     else if (key == "-maxAlloc" || key == "-maxalloc") {
       assert(!s.empty());
       u32 multiple = (s.back() == 'G') ? (1u << 30) : (1u << 20);
@@ -410,5 +408,5 @@ void Args::setDefaults() {
   uid = getUidFromPos(device);
   log("device %d, OpenCL %s, unique id '%s'\n", device, getDriverVersionByPos(device).c_str(), uid.c_str());
   for (auto& p : {proofResultDir, proofToVerifyDir, cacheDir}) { fs::create_directory(p); }
-  File::openAppend(resultsFile);  // verify that it's possible to write results
+  File::openAppend("results.txt");  // verify that it's possible to write results
 }

--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -408,5 +408,9 @@ void Args::setDefaults() {
   uid = getUidFromPos(device);
   log("device %d, OpenCL %s, unique id '%s'\n", device, getDriverVersionByPos(device).c_str(), uid.c_str());
   for (auto& p : {proofResultDir, proofToVerifyDir, cacheDir}) { fs::create_directory(p); }
-  File::openAppend("results.txt");  // verify that it's possible to write results
+
+  for (u32 i = 0; i < workers; ++i) {
+    string resultsFile = "results-" + to_string(i) + ".txt";
+    File::openAppend(resultsFile);  // verify that it's possible to write results
+  }
 }

--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -116,10 +116,7 @@ and should be able to run.
 
 Worktodo:
 PRPLL keeps the active tasks in per-worker files worktodo-0.txt, worktodo-1.txt etc in the local directory.
-These per-worker files are supplied from the global worktodo.txt file if -pool is used.
-In turn the global worktodo.txt can be supplied through the primenet.py script,
-either the one located at gpuowl/tools/primenet.py or https://download.mersenne.ca/primenet.py
-
+These files can be supplied through the autoprimenet.py script, located at https://download.mersenne.ca/AutoPrimeNet
 It is also possible to manually add exponents by adding lines of the form "PRP=118063003" to worktodo-<N>.txt
 
 
@@ -130,9 +127,6 @@ named "config.txt" in the prpll run directory.
 -h                 : print general help, list of FFTs, list of devices
 -info <fft>        : print detailed information about the given FFT; e.g. -h 1K:13:256
 -dir <folder>      : specify local work directory (containing worktodo.txt, results.txt, config.txt, gpuowl.log)
--pool <dir>        : specify a directory with the shared (pooled) worktodo.txt and results.txt
-                     Multiple PRPLL instances, each in its own directory, can share a pool of assignments and report
-                     the results back to the common pool.
 -verbose           : print more log, useful for developers
 -version           : print only the version and exit
 -user <name>       : specify the mersenne.org user name (for result reporting)
@@ -358,13 +352,6 @@ void Args::parse(const string& line) {
       }
       verifyPath = s;
     }
-    else if (key == "-pool") {
-      masterDir = s;
-      if (!masterDir.is_absolute()) {
-        log("-pool <path> requires an absolute path\n");
-        throw("-pool <path> requires an absolute path");
-      }
-    }
     else if (key == "-results") { resultsFile = s; }
     else if (key == "-maxAlloc" || key == "-maxalloc") {
       assert(!s.empty());
@@ -422,15 +409,6 @@ void Args::parse(const string& line) {
 void Args::setDefaults() {
   uid = getUidFromPos(device);
   log("device %d, OpenCL %s, unique id '%s'\n", device, getDriverVersionByPos(device).c_str(), uid.c_str());
-  
-  if (!masterDir.empty()) {
-    assert(masterDir.is_absolute());
-    for (filesystem::path* p : {&proofResultDir, &proofToVerifyDir, &cacheDir, &resultsFile}) {
-      if (p->is_relative()) { *p = masterDir / *p; }
-    }
-  }
-
   for (auto& p : {proofResultDir, proofToVerifyDir, cacheDir}) { fs::create_directory(p); }
-
   File::openAppend(resultsFile);  // verify that it's possible to write results
 }

--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -127,6 +127,8 @@ named "config.txt" in the prpll run directory.
 -h                 : print general help, list of FFTs, list of devices
 -info <fft>        : print detailed information about the given FFT; e.g. -h 1K:13:256
 -dir <folder>      : specify local work directory (containing worktodo.txt, results.txt, config.txt, gpuowl.log)
+-defaults <folder> : specify a directory with the shared config.txt and tune.txt files
+                     This option allows to use the same config for multiple PRPLL instances.
 -verbose           : print more log, useful for developers
 -version           : print only the version and exit
 -user <name>       : specify the mersenne.org user name (for result reporting)
@@ -351,6 +353,7 @@ void Args::parse(const string& line) {
       }
       verifyPath = s;
     }
+    else if (key == "-defaults") { sharedConfigDir = s; }
     else if (key == "-maxAlloc" || key == "-maxalloc") {
       assert(!s.empty());
       u32 multiple = (s.back() == 'G') ? (1u << 30) : (1u << 20);

--- a/src/Args.h
+++ b/src/Args.h
@@ -62,7 +62,6 @@ public:
   bool useCache = false;
   bool profile = false;
 
-  fs::path masterDir;
   fs::path proofResultDir = "proof";
   fs::path proofToVerifyDir = "proof-tmp";
   fs::path cacheDir = "kernel-cache";

--- a/src/Args.h
+++ b/src/Args.h
@@ -65,7 +65,7 @@ public:
   fs::path proofResultDir = "proof";
   fs::path proofToVerifyDir = "proof-tmp";
   fs::path cacheDir = "kernel-cache";
-  fs::path resultsFile = "results.txt";
+  // fs::path resultsFile = "results.txt";
   // fs::path tuneFile = "tune.txt";
 
   bool keepProof = false;

--- a/src/Args.h
+++ b/src/Args.h
@@ -62,6 +62,7 @@ public:
   bool useCache = false;
   bool profile = false;
 
+  fs::path sharedConfigDir;
   fs::path proofResultDir = "proof";
   fs::path proofToVerifyDir = "proof-tmp";
   fs::path cacheDir = "kernel-cache";

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -133,18 +133,19 @@ vector<string> tailFields(const std::string &AID, const Args &args) {
 }
 
 void writeResult(u32 E, const char *workType, const string &status, const std::string &AID, const Args &args,
-                 const vector<string>& extras) {
+                 const vector<string>& extras, u32 instance) {
   vector<string> fields = commonFields(E, workType, status);
   fields += extras;
   fields += tailFields(AID, args);
   string s = json(std::move(fields));
   log("%s\n", s.c_str());
-  File::append("results.txt", s + '\n');
+  string resultsFile = "results-" + to_string(instance) + ".txt";
+  File::append(resultsFile, s + '\n');
 }
 
 }
 
-void Task::writeResultPRP(const Args &args, bool isPrime, u64 res64, const string& res2048, u32 fftSize, u32 nErrors, const fs::path& proofPath) const {
+void Task::writeResultPRP(const Args &args, bool isPrime, u64 res64, const string& res2048, u32 fftSize, u32 nErrors, const fs::path& proofPath, u32 instance) const {
   vector<string> fields{json("res64", hex(res64)),
                         json("res2048", res2048),
                         json("residue-type", 1),
@@ -165,20 +166,20 @@ void Task::writeResultPRP(const Args &args, bool isPrime, u64 res64, const strin
     }
   }
   
-  writeResult(exponent, "PRP-3", isPrime ? "P" : "C", AID, args, fields);
+  writeResult(exponent, "PRP-3", isPrime ? "P" : "C", AID, args, fields, instance);
 }
 
-void Task::writeResultLL(const Args &args, bool isPrime, u64 res64, u32 fftSize) const {
+void Task::writeResultLL(const Args &args, bool isPrime, u64 res64, u32 fftSize, u32 instance) const {
   vector<string> fields{json("res64", hex(res64)),
                         json("fft-length", fftSize),
                         json("shift-count", 0),
                         json("error-code", "00000000"), // I don't know the meaning of this
   };
 
-  writeResult(exponent, "LL", isPrime ? "P" : "C", AID, args, fields);
+  writeResult(exponent, "LL", isPrime ? "P" : "C", AID, args, fields, instance);
 }
 
-void Task::writeResultCERT(const Args &args, array <u64, 4> hash, u32 squarings, u32 fftSize) const {
+void Task::writeResultCERT(const Args &args, array <u64, 4> hash, u32 squarings, u32 fftSize, u32 instance) const {
   string hexhash = hex(hash[3]) + hex(hash[2]) + hex(hash[1]) + hex(hash[0]);
   vector<string> fields{json("worktype", "Cert"),
 			json("exponent", exponent),
@@ -191,7 +192,8 @@ void Task::writeResultCERT(const Args &args, array <u64, 4> hash, u32 squarings,
   fields += tailFields(AID, args);
   string s = json(std::move(fields));
   log("%s\n", s.c_str());
-  File::append("results.txt", s + '\n');
+  string resultsFile = "results-" + to_string(instance) + ".txt";
+  File::append(resultsFile, s + '\n');
 }
 
 void Task::execute(GpuCommon shared, Queue *q, u32 instance) {
@@ -216,11 +218,11 @@ void Task::execute(GpuCommon shared, Queue *q, u32 instance) {
     if (kind == PRP) {
       auto [tmpIsPrime, res64, nErrors, proofPath, res2048] = gpu->isPrimePRP(*this);
       isPrime = tmpIsPrime;
-      writeResultPRP(*shared.args, isPrime, res64, res2048, fft.size(), nErrors, proofPath);
+      writeResultPRP(*shared.args, isPrime, res64, res2048, fft.size(), nErrors, proofPath, instance);
     } else { // LL
       auto [tmpIsPrime, res64] = gpu->isPrimeLL(*this);
       isPrime = tmpIsPrime;
-      writeResultLL(*shared.args, isPrime, res64, fft.size());
+      writeResultLL(*shared.args, isPrime, res64, fft.size(), instance);
     }
 
     Worktodo::deleteTask(*this, instance);
@@ -232,7 +234,7 @@ void Task::execute(GpuCommon shared, Queue *q, u32 instance) {
     }
   } else if (kind == CERT) {
     auto sha256 = gpu->isCERT(*this);
-    writeResultCERT(*shared.args, sha256, squarings, fft.size());
+    writeResultCERT(*shared.args, sha256, squarings, fft.size(), instance);
     Worktodo::deleteTask(*this, instance);
   } else {
     throw "Unexpected task kind " + to_string(kind);

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -139,7 +139,7 @@ void writeResult(u32 E, const char *workType, const string &status, const std::s
   fields += tailFields(AID, args);
   string s = json(std::move(fields));
   log("%s\n", s.c_str());
-  File::append(args.resultsFile, s + '\n');
+  File::append("results.txt", s + '\n');
 }
 
 }
@@ -191,7 +191,7 @@ void Task::writeResultCERT(const Args &args, array <u64, 4> hash, u32 squarings,
   fields += tailFields(AID, args);
   string s = json(std::move(fields));
   log("%s\n", s.c_str());
-  File::append(args.resultsFile, s + '\n');
+  File::append("results.txt", s + '\n');
 }
 
 void Task::execute(GpuCommon shared, Queue *q, u32 instance) {

--- a/src/Task.h
+++ b/src/Task.h
@@ -27,7 +27,7 @@ public:
   string verifyPath; // For Verify
   void execute(GpuCommon shared, Queue* q, u32 instance);
 
-  void writeResultPRP(const Args&, bool isPrime, u64 res64, const std::string& res2048, u32 fftSize, u32 nErrors, const fs::path& proofPath) const;
-  void writeResultLL(const Args&, bool isPrime, u64 res64, u32 fftSize) const;
-  void writeResultCERT(const Args&, array <u64, 4> hash, u32 squarings, u32 fftSize) const;
+  void writeResultPRP(const Args&, bool isPrime, u64 res64, const std::string& res2048, u32 fftSize, u32 nErrors, const fs::path& proofPath, u32 instance) const;
+  void writeResultLL(const Args&, bool isPrime, u64 res64, u32 fftSize, u32 instance) const;
+  void writeResultCERT(const Args&, array <u64, 4> hash, u32 squarings, u32 fftSize, u32 instance) const;
 };

--- a/src/TuneEntry.cpp
+++ b/src/TuneEntry.cpp
@@ -41,9 +41,6 @@ bool TuneEntry::willUpdate(const vector<TuneEntry>& results) const {
 
 vector<TuneEntry> TuneEntry::readTuneFile(const Args& args) {
   fs::path tuneFile = "tune.txt";
-  if (!fs::exists(tuneFile)) {
-    tuneFile = args.masterDir / "tune.txt";
-  }
 
   // if (!fs::exists(tuneFile)) { log("Tune file %s not found\n", tuneFile.string().c_str()); }
 

--- a/src/TuneEntry.cpp
+++ b/src/TuneEntry.cpp
@@ -41,6 +41,9 @@ bool TuneEntry::willUpdate(const vector<TuneEntry>& results) const {
 
 vector<TuneEntry> TuneEntry::readTuneFile(const Args& args) {
   fs::path tuneFile = "tune.txt";
+  if (!fs::exists(tuneFile)) {
+    tuneFile = args.sharedConfigDir / "tune.txt";
+  }
 
   // if (!fs::exists(tuneFile)) { log("Tune file %s not found\n", tuneFile.string().c_str()); }
 

--- a/src/Worktodo.cpp
+++ b/src/Worktodo.cpp
@@ -92,18 +92,25 @@ std::optional<Task> parse(const std::string& line) {
   return {};
 }
 
-// Among the valid tasks from fileName, return the "best" which means the smallest CERT, or otherwise the exponent PRP/LL
+// Process CERT tasks with priority
 static std::optional<Task> bestTask(const fs::path& fileName) {
-  optional<Task> best;
+  optional<Task> firstNonCert;
+
   for (const string& line : File::openRead(fileName)) {
     optional<Task> task = parse(line);
-    if (task && (!best
-                 || (best->kind != Task::CERT && task->kind == Task::CERT)
-                 || ((best->kind != Task::CERT || task->kind == Task::CERT) && task->exponent < best->exponent))) {
-      best = task;
+    if (!task)
+      continue;
+
+    if (task->kind == Task::CERT) {
+      return task;
+    }
+
+    if (!firstNonCert) {
+      firstNonCert = task;
     }
   }
-  return best;
+
+  return firstNonCert;
 }
 
 string workName(i32 instance) { return "worktodo-" + to_string(instance) + ".txt"; }

--- a/src/Worktodo.cpp
+++ b/src/Worktodo.cpp
@@ -113,52 +113,6 @@ optional<Task> getWork(Args& args, i32 instance) {
 
   // Try to get a task from the local worktodo-<N> file.
   if (optional<Task> task = bestTask(localWork)) { return task; }
-
-  if (args.masterDir.empty()) { return {}; }
-
-  fs::path worktodo = args.masterDir / "worktodo.txt";
-
-  /*
-    We need to aquire a task from the global worktodo.txt, and "atomically"
-    add the task to the local worktodo-N.txt and remove it from worktodo.txt
-
-    Below we call the global worktodo.txt "global worktodo", and worktodo-N.txt "local worktodo".
-
-    We want to avoid filesystem-based locking, so we approximate it this way:
-    1. read the file-size of the global worktodo
-    2. read one task from the global worktodo
-    3. append the task to the local worktodo
-    4. write the new content of the global worktodo without the task to a temporary file
-    5. compare the size of the global worktodo with its initial size (as an heuristic to detect modifications to it)
-    6a. if the size is not changed, rename the temporary file to global worktodo and done
-    6b. if the size is changed (i.e. global worktodo was modified in the meantime):
-       7. remove the task from the local worktodo (undo the local task add)
-       8. start again (from step 1)
-  */
-
-  for (int retry = 0; retry < 2; ++retry) {
-    u64 initialSize = fileSize(worktodo);
-    if (!initialSize) { return {}; }
-
-    optional<Task> task = bestTask(worktodo);
-    if (!task) { return {}; }
-
-    string workLine = task->line;
-    File::append(localWork, workLine);
-
-    if (deleteLine(worktodo, workLine, initialSize)) {
-      return task;
-    }
-
-    // Undo add to local worktodo. Attempt twice.
-    bool found = deleteLine(localWork, workLine) || deleteLine(localWork, workLine);
-    assert(found);
-    if (!found) { return {}; }
-  }
-
-  log("Could not extract a task from '%s'\n", worktodo.string().c_str());
-  // must be tough luck to be preempted twice while mutating the global worktodo
-  assert(false);
   return {};
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,11 +67,20 @@ int main(int argc, char **argv) {
       }
     }
 
+    fs::path sharedConfigDir;
+    {
+      Args args{true};
+      args.readConfig("config.txt");
+      args.parse(mainLine);
+      sharedConfigDir = args.sharedConfigDir;
+    }
+
     initLog("gpuowl-0.log");
     log("PRPLL %s starting\n", VERSION);
     
     Args args;
 
+    if (!sharedConfigDir.empty()) { args.readConfig(sharedConfigDir / "config.txt"); }
     args.readConfig("config.txt");
     args.parse(mainLine);
     args.setDefaults();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,21 +66,12 @@ int main(int argc, char **argv) {
         fs::current_path(args.dir);
       }
     }
-    
-    fs::path poolDir;
-    {
-      Args args{true};
-      args.readConfig("config.txt");
-      args.parse(mainLine);
-      poolDir = args.masterDir;
-    }
-        
+
     initLog("gpuowl-0.log");
     log("PRPLL %s starting\n", VERSION);
     
     Args args;
 
-    if (!poolDir.empty()) { args.readConfig(poolDir / "config.txt"); }
     args.readConfig("config.txt");
     args.parse(mainLine);
     args.setDefaults();


### PR DESCRIPTION
A second attempt to make PRPLL compatible with AutoPrimeNet, version 1.1.
This PR includes the following changes:

- Workers now write results to worker-specific `results-<n>.txt` files
- Assignments are processed in order in which they appear in `worktodo-<n>.txt`, but CERTs have a priority over other assignments
- The `-results` option is removed, as AutoPrimeNet assumes fixed naming format of `results-<n>.txt` files
- The `-pool` option is removed, as it is incompatible with PrimeNet API and is also not really needed for a setup with AutoPrimeNet
- I added the `-defaults` option to specify a directory with `config.txt` and `tune.txt` files, that allows to have a shared config across multiple PRPLL instances

As it was discussed on the mailing list, there are more updates to be implemented (e.g. for proper support of CERT assignments), but this PR can be a starting point and can allow to test the basic functionality of PRPLL + AutoPrimeNet setup.