### PR TITLE
Fixed GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm]
         cxx: [g++, clang++]
+        exclude:
+        - os: ubuntu-22.04-arm
+          cxx: clang++
       fail-fast: false
     env:
       CXX: ${{ matrix.cxx }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install
       run: |
         sudo apt-get update -y
@@ -27,14 +30,14 @@ jobs:
         $CXX --version
     - name: Script
       run: |
-        make prpll -O -j "$(nproc)"
+        make -O -j "$(nproc)"
         cd build-release
         rm -f -- *.o
         ./prpll -h
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: always()
       with:
-        name: ${{ matrix.os }}_${{ matrix.cxx }}_prpll
+        name: ${{ matrix.os }}_${{ endsWith(matrix.os, '-arm') && 'arm' || 'x86' }}_${{ matrix.cxx }}_prpll
         path: ${{ github.workspace }}
     - name: Cppcheck
       run: cppcheck --enable=all --force .
@@ -49,15 +52,17 @@ jobs:
   Windows:
     name: Windows
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [windows-latest] # windows-11-arm
         cxx: [g++, clang++]
       fail-fast: false
     env:
       CXX: ${{ matrix.cxx }}
+      PACKAGE_PREFIX: mingw-w64-${{ endsWith(matrix.os, '-arm') && 'clang-aarch64' || 'x86_64' }}-
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Before Install
       run: |
         echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
@@ -66,7 +71,7 @@ jobs:
         echo "LIBPATH=-LC:\msys64\mingw64\lib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - name: Install
       run: |
-        pacman -S --noconfirm mingw-w64-x86_64-gmp mingw-w64-x86_64-opencl-icd
+        pacman -S --noconfirm "${env:PACKAGE_PREFIX}opencl-icd"
         & $env:CXX --version
     - name: Install Clang
       if: ${{ matrix.cxx == 'clang++' }}
@@ -74,34 +79,40 @@ jobs:
         pacman -S --noconfirm mingw-w64-x86_64-clang
         & $env:CXX --version
     - name: Script
-      run: | # Cannot use `make exe`, as the OpenCL ICD Loader does not support static linking
-        make prpll -O -j $env:NUMBER_OF_PROCESSORS
+      run: |
+        make -O -j $env:NUMBER_OF_PROCESSORS
         cd build-release
         rm *.o
         .\prpll.exe -h
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: always()
       with:
-        name: win_${{ matrix.cxx }}_prpll
+        name: win_${{ endsWith(matrix.os, '-arm') && 'arm' || 'x86' }}_${{ matrix.cxx }}_prpll
         path: ${{ github.workspace }}
 
   macOS:
     name: macOS
 
-    runs-on: macos-13
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-15-intel, macos-latest]
+      fail-fast: false
+    env:
+      CXX: g++-15
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install
       run: |
-        brew install gcc@14
+        $CXX --version
     - name: Script
       run: |
-        make prpll -j "$(sysctl -n hw.ncpu)"
+        make -j "$(sysctl -n hw.ncpu)"
         cd build-release
         rm -f -- *.o
         ./prpll -h
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: always()
       with:
-        name: macos_prpll
+        name: macos_${{ endsWith(matrix.os, '-intel') && 'x86' || 'arm' }}_prpll
         path: ${{ github.workspace }}

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ HOST_OS = $(shell uname -s)
 
 ifeq ($(HOST_OS), Darwin)
 # Real GCC (not clang), needed for 128-bit floats and std::filesystem::path
-CXX = g++-14
+CXX ?= g++-15
 else
-CXX = g++
+CXX ?= g++
 endif
 
 ifneq ($(findstring MINGW, $(HOST_OS)), MINGW)
@@ -45,7 +45,7 @@ else
 
 BIN=build-release
 
-CXXFLAGS = -O2 -DNDEBUG $(COMMON_FLAGS)
+CXXFLAGS = -O3 -DNDEBUG $(COMMON_FLAGS)
 STRIP=-s
 
 endif
@@ -90,7 +90,7 @@ $(BIN)/%.o : src/%.cpp $(DEPDIR)/%.d
 # src/bundle.cpp is just a wrapping of the OpenCL sources (*.cl) as a C string.
 
 src/bundle.cpp: genbundle.sh src/cl/*.cl
-	./genbundle.sh $^ > src/bundle.cpp
+	bash genbundle.sh $^ > src/bundle.cpp
 
 $(DEPDIR)/%.d: ;
 .PRECIOUS: $(DEPDIR)/%.d

--- a/genbundle.sh
+++ b/genbundle.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 cat <<EOM
 // Copyright (C) Mihai Preda
 // Generated file, do not edit. See genbundle.sh and src/cl/*.cl
@@ -9,24 +10,24 @@ EOM
 
 names=
 
-for xx in $*
+for xx in "$@"
 do
-    x=`basename $xx`
+    x=$(basename "$xx")
     
     if [ "$x" = "genbundle.sh" ] ; then continue ; fi
     
     names=${names}\"${x}\",
 
-    echo // $xx
+    echo "// $xx"
     #echo const char ${x}_cl[] = R\"cltag\(
-    echo R\"cltag\(
-    cat $xx
-    echo \)cltag\"\,
+    echo 'R"cltag('
+    cat "$xx"
+    echo ')cltag",'
     echo
 done
-echo \}\;
+echo '};'
 
-echo static const std::vector\<const char*\> CL_FILE_NAMES\{${names}\}\;
+echo "static const std::vector<const char*> CL_FILE_NAMES{${names}};"
 
 cat <<EOM
 const std::vector<const char*>& getClFileNames() { return CL_FILE_NAMES; }

--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -118,7 +118,7 @@ Worktodo:
 PRPLL keeps the active tasks in per-worker files worktodo-0.txt, worktodo-1.txt etc in the local directory.
 These per-worker files are supplied from the global worktodo.txt file if -pool is used.
 In turn the global worktodo.txt can be supplied through the primenet.py script,
-either the one located at gpuowl/tools/primenet.py or https://download.mersenne.ca/primenet.py
+either the one located at gpuowl/tools/primenet.py or https://download.mersenne.ca/AutoPrimeNet
 
 It is also possible to manually add exponents by adding lines of the form "PRP=118063003" to worktodo-<N>.txt
 

--- a/src/common.h
+++ b/src/common.h
@@ -13,7 +13,7 @@ using i64 = int64_t;
 using u64 = uint64_t;
 using i128 = __int128;
 using u128 = unsigned __int128;
-using f128 = __float128;
+// using f128 = __float128;
 
 static_assert(sizeof(u8)  == 1, "size u8");
 static_assert(sizeof(u32) == 4, "size u32");

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -947,7 +947,7 @@ void Tune::tune() {
       config.write("\n  -log 1000000\n");
     }
     if (args->workers < 2) {
-      config.write("\n# Running two workers sometimes gives better throughput.  Autoprimenet will need to create up a second worktodo file.");
+      config.write("\n# Running two workers sometimes gives better throughput.  AutoPrimeNet will need to create up a second worktodo file (use --num-workers 2).");
       config.write("\n#  -workers 2\n");
       config.write("\n# Changing TAIL_KERNELS to 3 when running two workers may be better.");
       config.write("\n#  -use TAIL_KERNELS=3\n");


### PR DESCRIPTION
* Fixed GitHub Actions CI
    * Replaced unsupported macOS 13 runner with the new macOS 15 Intel runner.
    * Updated to test with Linux and macOS ARM runners.
    * Updated actions/checkout. Fixes #343
    * Updated actions/upload-artifact. Fixes #347
* Fixed Makefile to allow building with Clang again.
* Fixed ARM builds by commenting out the unused `__float128` datatype. Fixes #326
* Fixed permission error with `genbundle.sh` script on some systems by explicitly running it with Bash.
    * Also fixed the ShellCheck errors.
* Enabled `-O3` optimization.
* Updated link to AutoPrimeNet.

CC: @N-Storm